### PR TITLE
Fix arguments of sed command for Mac OS.

### DIFF
--- a/pre_commit_hooks/trailing_whitespace_fixer.py
+++ b/pre_commit_hooks/trailing_whitespace_fixer.py
@@ -20,7 +20,7 @@ def fix_trailing_whitespace(argv):
     if bad_whitespace_files:
         for bad_whitespace_file in bad_whitespace_files:
             print('Fixing {0}'.format(bad_whitespace_file))
-            local['sed']['-i', '-e', 's/[[:space:]]*$//', bad_whitespace_file]()
+            local['sed']['-i', '', '-e', 's/[[:space:]]*$//', bad_whitespace_file]()
         return 1
     else:
         return 0


### PR DESCRIPTION
On MacOS `sed -i -e xxxx` creates a backup file whose name is `xxxx-e`.
This change prevents from creating such a backup file.
Here is a related article on Stackoverflow.
http://stackoverflow.com/questions/5171901/sed-command-find-and-replace-in-file-and-overwrite-file-doesnt-work-it-empties#comment40178991_5171935

I tested my code on only Mac OS.
