### PR TITLE
Add eyaml support for check-yaml hook

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -49,7 +49,7 @@
     description: This hook checks yaml files for parseable syntax.
     entry: check-yaml
     language: python
-    files: \.(yaml|yml)$
+    files: \.(yaml|yml|eyaml)$
 -   id: debug-statements
     name: Debug Statements (Python)
     description: This hook checks that debug statements (pdb, ipdb, pudb) are not imported on commit.


### PR DESCRIPTION
In Puppet a common practice is to add eyaml files to hiera for security purposes. 