### PR TITLE
refactor detect_merge_conflict_test.py

### DIFF
--- a/pre_commit_hooks/check_merge_conflict.py
+++ b/pre_commit_hooks/check_merge_conflict.py
@@ -6,7 +6,8 @@ import sys
 
 CONFLICT_PATTERNS = [
     '<<<<<<< ',
-    '=======',
+    '======= ',
+    '=======\n',
     '>>>>>>> '
 ]
 WARNING_MSG = 'Merge conflict string "{0}" found in {1}:{2}'

--- a/pre_commit_hooks/check_merge_conflict.py
+++ b/pre_commit_hooks/check_merge_conflict.py
@@ -13,7 +13,7 @@ CONFLICT_PATTERNS = [
 WARNING_MSG = 'Merge conflict string "{0}" found in {1}:{2}'
 
 
-def is_in_merge_conflict():
+def is_in_merge():
     return (
         os.path.exists(os.path.join('.git', 'MERGE_MSG')) and
         os.path.exists(os.path.join('.git', 'MERGE_HEAD'))
@@ -25,7 +25,7 @@ def detect_merge_conflict(argv=None):
     parser.add_argument('filenames', nargs='*')
     args = parser.parse_args(argv)
 
-    if not is_in_merge_conflict():
+    if not is_in_merge():
         return 0
 
     retcode = 0

--- a/tests/check_merge_conflict_test.py
+++ b/tests/check_merge_conflict_test.py
@@ -47,7 +47,7 @@ def f1_is_a_conflict_file(in_tmpdir):
 
 
 @pytest.mark.parametrize(
-    'failing_contents', ('<<<<<<< HEAD', '=======', '>>>>>>> master'),
+    'failing_contents', ('<<<<<<< HEAD\n', '=======\n', '>>>>>>> master\n'),
 )
 @pytest.mark.usefixtures('f1_is_a_conflict_file')
 def test_merge_conflicts_failing(failing_contents):
@@ -56,7 +56,7 @@ def test_merge_conflicts_failing(failing_contents):
 
 
 @pytest.mark.parametrize(
-    'ok_contents', ('# <<<<<<< HEAD', '# =======', 'import my_module', ''),
+    'ok_contents', ('# <<<<<<< HEAD\n', '# =======\n', 'import my_module', ''),
 )
 @pytest.mark.usefixtures('f1_is_a_conflict_file')
 def test_merge_conflicts_ok(ok_contents):
@@ -67,5 +67,5 @@ def test_merge_conflicts_ok(ok_contents):
 @pytest.mark.usefixtures('in_tmpdir')
 def test_does_not_care_when_not_in_a_conflict():
     with io.open('README.md', 'w') as readme_file:
-        readme_file.write('pre-commit\n=================\n')
+        readme_file.write('problem\n=======\n')
     assert detect_merge_conflict(['README.md']) == 0

--- a/tests/check_merge_conflict_test.py
+++ b/tests/check_merge_conflict_test.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import io
+import os
 
 import pytest
 
@@ -43,16 +44,51 @@ def f1_is_a_conflict_file(in_tmpdir):
             'parent\n'
             '>>>>>>>'
         )
+        assert os.path.exists(os.path.join('.git', 'MERGE_MSG'))
         yield
+
+
+@pytest.yield_fixture
+def repository_is_pending_merge(in_tmpdir):
+    # Make a (non-conflicting) merge
+    cmd_output('git', 'init', 'repo1')
+    with cwd('repo1'):
+        io.open('f1', 'w').close()
+        cmd_output('git', 'add', 'f1')
+        cmd_output('git', 'commit', '-m' 'commit1')
+
+    cmd_output('git', 'clone', 'repo1', 'repo2')
+
+    # Commit in master
+    with cwd('repo1'):
+        write_file('f1', 'parent\n')
+        cmd_output('git', 'commit', '-am', 'master commit2')
+
+    # Commit in clone and pull without committing
+    with cwd('repo2'):
+        write_file('f2', 'child\n')
+        cmd_output('git', 'add', 'f2')
+        cmd_output('git', 'commit', '-m', 'clone commit2')
+        cmd_output('git', 'pull', '--no-commit')
+        # We should end up in a pending merge
+        assert io.open('f1').read().startswith('parent\n')
+        assert io.open('f2').read().startswith('child\n')
+        assert os.path.exists(os.path.join('.git', 'MERGE_HEAD'))
+        yield
+
+
+@pytest.mark.usefixtures('f1_is_a_conflict_file')
+def test_merge_conflicts_git():
+    assert detect_merge_conflict(['f1']) == 1
 
 
 @pytest.mark.parametrize(
     'failing_contents', ('<<<<<<< HEAD\n', '=======\n', '>>>>>>> master\n'),
 )
-@pytest.mark.usefixtures('f1_is_a_conflict_file')
+@pytest.mark.usefixtures('repository_is_pending_merge')
 def test_merge_conflicts_failing(failing_contents):
-    write_file('f1', failing_contents)
-    assert detect_merge_conflict(['f1']) == 1
+    write_file('f2', failing_contents)
+    assert detect_merge_conflict(['f2']) == 1
 
 
 @pytest.mark.parametrize(
@@ -65,7 +101,7 @@ def test_merge_conflicts_ok(ok_contents):
 
 
 @pytest.mark.usefixtures('in_tmpdir')
-def test_does_not_care_when_not_in_a_conflict():
+def test_does_not_care_when_not_in_a_merge():
     with io.open('README.md', 'w') as readme_file:
         readme_file.write('problem\n=======\n')
     assert detect_merge_conflict(['README.md']) == 0


### PR DESCRIPTION
Building on [PR#55](https://github.com/pre-commit/pre-commit-hooks/pull/55), this subsumes those changes and adds some refactoring of the tests to better reflect the fact that we want to run merge conflict detection any time we are in a merge, whether the particular file we're looking at is in a merge state or not.  We also want to use git to generate a real merge conflict and check that we detect it (in case formatting changes for some reason).
Also, rename the function that checks whether repository is pending merge to reflect that it is doing that, and not actually detecting merge conflict.