### PR TITLE
detect_private_key: print *filenames*, not the key

### DIFF
--- a/pre_commit_hooks/detect_private_key.py
+++ b/pre_commit_hooks/detect_private_key.py
@@ -3,6 +3,12 @@ from __future__ import print_function
 import argparse
 import sys
 
+BLACKLIST = [
+    b'BEGIN RSA PRIVATE KEY',
+    b'BEGIN DSA PRIVATE KEY',
+    b'BEGIN EC PRIVATE KEY',
+]
+
 
 def detect_private_key(argv=None):
     parser = argparse.ArgumentParser()
@@ -12,11 +18,10 @@ def detect_private_key(argv=None):
     private_key_files = []
 
     for filename in args.filenames:
-        content = open(filename, 'rb').read()
-        if b'BEGIN RSA PRIVATE KEY' in content:
-            private_key_files.append(content)
-        if b'BEGIN DSA PRIVATE KEY' in content:
-            private_key_files.append(content)
+        with open(filename, 'rb') as f:
+            content = f.read()
+            if any(line in content for line in BLACKLIST):
+                private_key_files.append(filename)
 
     if private_key_files:
         for private_key_file in private_key_files:

--- a/tests/detect_private_key_test.py
+++ b/tests/detect_private_key_test.py
@@ -8,6 +8,7 @@ from pre_commit_hooks.detect_private_key import detect_private_key
 TESTS = (
     (b'-----BEGIN RSA PRIVATE KEY-----', 1),
     (b'-----BEGIN DSA PRIVATE KEY-----', 1),
+    (b'-----BEGIN EC PRIVATE KEY-----', 1),
     (b'ssh-rsa DATA', 0),
     (b'ssh-dsa DATA', 0),
     # Some arbitrary binary data


### PR DESCRIPTION
Currently it prints *the entire content* of the problem file (which might be really long, e.g. a Python test file with embedded dummy key) but doesn't actually print the file name.