### PR TITLE
Sort requirements.txt case-insensitively

### DIFF
--- a/pre_commit_hooks/requirements_txt_fixer.py
+++ b/pre_commit_hooks/requirements_txt_fixer.py
@@ -19,8 +19,8 @@ class Requirement(object):
             return False
         else:
             return (
-                self.value.partition(b'==') <
-                requirement.value.partition(b'==')
+                self.value.lower().partition(b'==') <
+                requirement.value.lower().partition(b'==')
             )
 
 

--- a/tests/requirements_txt_fixer_test.py
+++ b/tests/requirements_txt_fixer_test.py
@@ -16,6 +16,7 @@ TESTS = (
     (b'\nfoo\nbar\n', 1, b'bar\n\nfoo\n'),
     (b'\nbar\nfoo\n', 0, b'\nbar\nfoo\n'),
     (b'pyramid==1\npyramid-foo==2\n', 0, b'pyramid==1\npyramid-foo==2\n'),
+    (b'ocflib\nDjango\nPyMySQL\n', 1, b'Django\nocflib\nPyMySQL\n'),
 )
 
 


### PR DESCRIPTION
Every time I `pip freeze` to update my requirements.txt and then run pre-commit, I get diffs like:
```diff
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
+Django==1.8.3
+PyMySQL==0.6.6
+SQLAlchemy==1.0.8
 colorama==0.3.3
 cracklib==2.9.3
-Django==1.8.3
 dnspython3==1.12.0
 ecdsa==0.13
 gunicorn==19.3.0
@@ -10,7 +12,5 @@ paramiko==1.15.2
 pexpect==3.2
 pyasn1==0.1.8
 pycrypto==2.6.1
-PyMySQL==0.6.6
 pysnmp==4.2.5
 requests==2.7.0
-SQLAlchemy==1.0.8
```

IMO the pip behavior is more useful (putting capitalized deps at the top seems unhelpful, especially since they can appear lowercase or uppercase and still be correct). Plus this avoids unnecessary churn.

FWIW I think this is a behavior of newer versions of pip; old pip (1.5.6) seems to keep capitals at the top, while the latest doesn't.