### PR TITLE
Fixed regex matching for django test file names

### DIFF
--- a/pre_commit_hooks/tests_should_end_in_test.py
+++ b/pre_commit_hooks/tests_should_end_in_test.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import argparse
 import re
 import sys
+from os.path import basename
 
 
 def validate_files(argv=None):
@@ -15,14 +16,13 @@ def validate_files(argv=None):
     args = parser.parse_args(argv)
 
     retcode = 0
-    test_name_pattern = '.*_test.py'
-    if args.django:
-        test_name_pattern = 'test.*.py'
+    test_name_pattern = 'test_.*.py' if args.django else '.*_test.py'
     for filename in args.filenames:
+        base = basename(filename)
         if (
-                not re.match(test_name_pattern, filename) and
-                not filename.endswith('__init__.py') and
-                not filename.endswith('/conftest.py')
+                not re.match(test_name_pattern, base) and
+                not base == '__init__.py' and
+                not base == 'conftest.py'
         ):
             retcode = 1
             print(

--- a/tests/tests_should_end_in_test_test.py
+++ b/tests/tests_should_end_in_test_test.py
@@ -12,12 +12,17 @@ def test_validate_files_one_fails():
 
 
 def test_validate_files_django_all_pass():
-    ret = validate_files(['--django', 'test_foo.py', 'test_bar.py'])
+    ret = validate_files(['--django', 'test_foo.py', 'test_bar.py', 'tests/test_baz.py'])
     assert ret == 0
 
 
 def test_validate_files_django_one_fails():
     ret = validate_files(['--django', 'not_test_ending.py', 'test_foo.py'])
+    assert ret == 1
+
+
+def test_validate_nested_files_django_one_fails():
+    ret = validate_files(['--django', 'tests/not_test_ending.py', 'test_foo.py'])
     assert ret == 1
 
 


### PR DESCRIPTION
Addresses issue at https://github.com/pre-commit/pre-commit-hooks/issues/88, where the regex for django mistook the directory as part of the filename and, as a result failed to flag bad filenames.  

Implementation itself, strips off the directory path, leaving just the basename so that we don't have to run endswith. Also, re.match() wouldn't have worked with directories such as 'foo/tests/bar' anyways since it checks at the **beginning** of the string.