### PR TITLE
Addding no-sort-keys to pretty_format_json

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Add this to your `.pre-commit-config.yaml`
     - Use `args: ['--django']` to match `test*.py` instead.
 - `pyflakes` - Run pyflakes on your python files.
 - `pretty-format-json` - Checks that all your JSON files are pretty
+    - Use `args: ['--autofix']` to automatically fixing the encountered not-pretty-formatted files and
+    `args: ['--no-sort-keys']` to disable the sort on the keys.
 - `requirements-txt-fixer` - Sorts entries in requirements.txt
 - `trailing-whitespace` - Trims trailing whitespace.
     - Markdown linebreak trailing spaces preserved for `.md` and`.markdown`;

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -6,10 +6,10 @@ import sys
 import simplejson
 
 
-def _get_pretty_format(contents, indent):
+def _get_pretty_format(contents, indent, no_sort_keys):
     return simplejson.dumps(
         simplejson.loads(contents),
-        sort_keys=True,
+        sort_keys=no_sort_keys,
         indent=indent
     ) + "\n"  # dumps don't end with a newline
 
@@ -34,6 +34,13 @@ def pretty_format_json(argv=None):
         default=2,
         help='Number of indent spaces used to pretty-format files'
     )
+    parser.add_argument(
+        '--no-sort-keys',
+        action='store_true',
+        dest='no_sort_keys',
+        default=False,
+        help='Do not sort the keys'
+    )
 
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)
@@ -46,7 +53,7 @@ def pretty_format_json(argv=None):
             contents = f.read()
             f.close()
 
-            pretty_contents = _get_pretty_format(contents, args.indent)
+            pretty_contents = _get_pretty_format(contents, args.indent, (not args.no_sort_keys))
 
             if contents != pretty_contents:
                 print("File {0} is not pretty-formatted".format(json_file))


### PR DESCRIPTION
This allows to disable the sort on the keys.

Still works the same as before if the new argument is not specified.