### PR TITLE
Increase robustness of tests involving `git`

### DIFF
--- a/tests/check_added_large_files_test.py
+++ b/tests/check_added_large_files_test.py
@@ -80,11 +80,18 @@ xfailif_no_gitlfs = pytest.mark.xfail(
 def test_allows_gitlfs(temp_git_dir):  # pragma: no cover
     with temp_git_dir.as_cwd():
         # Work around https://github.com/github/git-lfs/issues/913
-        cmd_output('git', 'commit', '--allow-empty', '-m', 'foo')
+        cmd_output(
+            'git',
+            'commit',
+            '--no-gpg-sign',
+            '--allow-empty',
+            '-m',
+            'foo',
+        )
         cmd_output('git', 'lfs', 'install')
         temp_git_dir.join('f.py').write('a' * 10000)
         cmd_output('git', 'lfs', 'track', 'f.py')
-        cmd_output('git', 'add', '.')
+        cmd_output('git', 'add', '--', '.')
         # Should succeed
         assert main(('--maxkb', '9', 'f.py')) == 0
 
@@ -96,8 +103,8 @@ def test_moves_with_gitlfs(temp_git_dir):  # pragma: no cover
         cmd_output('git', 'lfs', 'track', 'a.bin', 'b.bin')
         # First add the file we're going to move
         temp_git_dir.join('a.bin').write('a' * 10000)
-        cmd_output('git', 'add', '.')
-        cmd_output('git', 'commit', '-am', 'foo')
+        cmd_output('git', 'add', '--', '.')
+        cmd_output('git', 'commit', '--no-gpg-sign', '-am', 'foo')
         # Now move it and make sure the hook still succeeds
         cmd_output('git', 'mv', 'a.bin', 'b.bin')
         assert main(('--maxkb', '9', 'b.bin')) == 0

--- a/tests/check_case_conflict_test.py
+++ b/tests/check_case_conflict_test.py
@@ -41,7 +41,7 @@ def test_file_conflicts_with_committed_file(temp_git_dir):
     with temp_git_dir.as_cwd():
         temp_git_dir.join('f.py').write("print('hello world')")
         cmd_output('git', 'add', 'f.py')
-        cmd_output('git', 'commit', '--no-verify', '-m', 'Add f.py')
+        cmd_output('git', 'commit', '--no-gpg-sign', '-n', '-m', 'Add f.py')
 
         temp_git_dir.join('F.py').write("print('hello world')")
         cmd_output('git', 'add', 'F.py')

--- a/tests/check_merge_conflict_test.py
+++ b/tests/check_merge_conflict_test.py
@@ -23,23 +23,23 @@ def f1_is_a_conflict_file(tmpdir):
     repo2 = tmpdir.join('repo2')
     repo2_f1 = repo2.join('f1')
 
-    cmd_output('git', 'init', repo1.strpath)
+    cmd_output('git', 'init', '--', repo1.strpath)
     with repo1.as_cwd():
         repo1_f1.ensure()
-        cmd_output('git', 'add', repo1_f1.strpath)
-        cmd_output('git', 'commit', '-m', 'commit1')
+        cmd_output('git', 'add', '--', repo1_f1.strpath)
+        cmd_output('git', 'commit', '--no-gpg-sign', '-m', 'commit1')
 
     cmd_output('git', 'clone', repo1.strpath, repo2.strpath)
 
     # Commit in master
     with repo1.as_cwd():
         repo1_f1.write('parent\n')
-        cmd_output('git', 'commit', '-am', 'master commit2')
+        cmd_output('git', 'commit', '--no-gpg-sign', '-am', 'master commit2')
 
     # Commit in clone and pull
     with repo2.as_cwd():
         repo2_f1.write('child\n')
-        cmd_output('git', 'commit', '-am', 'clone commit2')
+        cmd_output('git', 'commit', '--no-gpg-sign', '-am', 'clone commit2')
         cmd_output('git', 'pull', retcode=None)
         # We should end up in a merge conflict!
         f1 = repo2_f1.read()
@@ -73,21 +73,21 @@ def repository_is_pending_merge(tmpdir):
     cmd_output('git', 'init', repo1.strpath)
     with repo1.as_cwd():
         repo1_f1.ensure()
-        cmd_output('git', 'add', repo1_f1.strpath)
-        cmd_output('git', 'commit', '-m' 'commit1')
+        cmd_output('git', 'add', '--', repo1_f1.strpath)
+        cmd_output('git', 'commit', '--no-gpg-sign', '-m', 'commit1')
 
     cmd_output('git', 'clone', repo1.strpath, repo2.strpath)
 
     # Commit in master
     with repo1.as_cwd():
         repo1_f1.write('parent\n')
-        cmd_output('git', 'commit', '-am', 'master commit2')
+        cmd_output('git', 'commit', '--no-gpg-sign', '-am', 'master commit2')
 
     # Commit in clone and pull without committing
     with repo2.as_cwd():
         repo2_f2.write('child\n')
-        cmd_output('git', 'add', repo2_f2.strpath)
-        cmd_output('git', 'commit', '-m', 'clone commit2')
+        cmd_output('git', 'add', '--', repo2_f2.strpath)
+        cmd_output('git', 'commit', '--no-gpg-sign', '-m', 'clone commit2')
         cmd_output('git', 'pull', '--no-commit')
         # We should end up in a pending merge
         assert repo2_f1.read() == 'parent\n'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,5 +10,5 @@ from pre_commit_hooks.util import cmd_output
 @pytest.yield_fixture
 def temp_git_dir(tmpdir):
     git_dir = tmpdir.join('gits')
-    cmd_output('git', 'init', git_dir.strpath)
+    cmd_output('git', 'init', '--', git_dir.strpath)
     yield git_dir


### PR DESCRIPTION
1. Disable automatic `git commit` GPG-signing, since that requires interaction. This issue was encountered in practice by me, causing spurious test failures.
2. In case path operands could turn out to start with dashes, escape the operand list with `--`.