### PR TITLE
Update debug_statement_hook.py

### DIFF
--- a/pre_commit_hooks/debug_statement_hook.py
+++ b/pre_commit_hooks/debug_statement_hook.py
@@ -7,7 +7,7 @@ import collections
 import traceback
 
 
-DEBUG_STATEMENTS = set(['pdb', 'ipdb', 'pudb', 'q'])
+DEBUG_STATEMENTS = set(['pdb', 'ipdb', 'pudb', 'q', 'rdb'])
 
 
 DebugStatement = collections.namedtuple(


### PR DESCRIPTION
Adds celery rdb as debugger: http://docs.celeryproject.org/en/latest/tutorials/debugging.html