### PR TITLE
Update hooks.yaml

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -115,7 +115,7 @@
     name: Flake8
     description: This hook runs flake8.
     entry: flake8
-    language: python
+    language: system
     files: \.py$
 -   id: name-tests-test
     name: Tests should end in _test.py


### PR DESCRIPTION
I am not sure but I think flake should be run as a system script not as a python script. I did some tests with files that have pep8 errors and flake8 hook seems not detect them.