### PR TITLE
Add file patterns for trailing whitespace fixer

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -140,4 +140,4 @@
     description: This hook trims trailing whitespace.
     entry: trailing-whitespace-fixer
     language: python
-    files: \.(c|cpp|html|erb|slim|haml|ejs|jade|js|coffee|json|rb|md|py|css|scss|less|sh|tmpl|txt|yaml|yml|pp)$
+    files: \.(asciidoc|adoc|coffee|cpp|css|c|ejs|erb|h|haml|hh|hpp|hxx|html|in|jade|json|js|less|markdown|md|ml|mli|pp|py|rb|rs|R|scss|sh|slim|tmpl|txt|yaml|yml)$


### PR DESCRIPTION
* Add extensions for AsciiDoctor, C, C++, OCaml, R, Rust.
* Reorder alphabetically.

See #125.