### PR TITLE
handle editable requirements properly

### DIFF
--- a/pre_commit_hooks/requirements_txt_fixer.py
+++ b/pre_commit_hooks/requirements_txt_fixer.py
@@ -10,6 +10,19 @@ class Requirement(object):
         self.value = None
         self.comments = []
 
+    @property
+    def name(self):
+        if self.value is None:
+            return
+
+        if self.value == b'\n':
+            return
+
+        if self.value.startswith(b'-e '):
+            return self.value.lower().partition(b'=')[-1]
+
+        return self.value.lower().partition(b'==')[0]
+
     def __lt__(self, requirement):
         # \n means top of file comment, so always return True,
         # otherwise just do a string comparison with value.
@@ -18,10 +31,7 @@ class Requirement(object):
         elif requirement.value == b'\n':
             return False
         else:
-            return (
-                self.value.lower().partition(b'==') <
-                requirement.value.lower().partition(b'==')
-            )
+            return self.name < requirement.name
 
 
 def fix_requirements(f):

--- a/pre_commit_hooks/requirements_txt_fixer.py
+++ b/pre_commit_hooks/requirements_txt_fixer.py
@@ -12,12 +12,6 @@ class Requirement(object):
 
     @property
     def name(self):
-        if self.value is None:
-            return
-
-        if self.value == b'\n':
-            return
-
         if self.value.startswith(b'-e '):
             return self.value.lower().partition(b'=')[-1]
 

--- a/tests/requirements_txt_fixer_test.py
+++ b/tests/requirements_txt_fixer_test.py
@@ -15,6 +15,7 @@ TESTS = (
     (b'\nbar\nfoo\n', 0, b'\nbar\nfoo\n'),
     (b'pyramid==1\npyramid-foo==2\n', 0, b'pyramid==1\npyramid-foo==2\n'),
     (b'ocflib\nDjango\nPyMySQL\n', 1, b'Django\nocflib\nPyMySQL\n'),
+    (b'-e git+ssh://git_url@tag#egg=ocflib\nDjango\nPyMySQL\n', 1, b'Django\n-e git+ssh://git_url@tag#egg=ocflib\nPyMySQL\n'),
 )
 
 


### PR DESCRIPTION
Requirement fixer does not handles the requirements of the format `-e git+ssh://git_url@tag#egg=req` properly.
This results in these kind of requirements always ordered to the file top.
This is not in sync with the output given by `pip freeze`.
