### PR TITLE
Fix flake8-respect-noqa AttributeError

### DIFF
--- a/pre_commit_hooks/fix_encoding_pragma.py
+++ b/pre_commit_hooks/fix_encoding_pragma.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import argparse
 import collections
 
-expected_pragma = b'# -*- coding: utf-8 -*-\n'
+expected_pragma = b'# coding: utf-8\n'
 
 
 def has_coding(line):


### PR DESCRIPTION
`flake8-respect-noqa` 会导致以下报错，详见 https://travis-ci.com/xiachufang/xiachufang/builds/29409317 ，暂时移除 `flake8-respect-noqa` 否则 CI 会受影响

    AttributeError: Values instance has no attribute 'benchmark_keys'

另外从 upstream 更新了一下，目前跟 upstream 的 master 是同步的，同步完之后发现好像不需要把 `open` 都改成 `io.open()`，不会报跟 encoding 相关的问题了。