### PR TITLE
Add .groovy and .tex files to whitespace hooks

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -104,7 +104,7 @@
     description: Ensures that a file is either empty, or ends with one newline.
     entry: end-of-file-fixer
     language: python
-    files: \.(asciidoc|adoc|coffee|cpp|css|c|ejs|erb|h|haml|hh|hpp|hxx|html|in|jade|json|js|less|markdown|md|ml|mli|pp|py|rb|rs|R|scala|scss|sh|slim|tmpl|ts|txt|yaml|yml)$
+    files: \.(asciidoc|adoc|coffee|cpp|css|c|ejs|erb|groovy|h|haml|hh|hpp|hxx|html|in|jade|json|js|less|markdown|md|ml|mli|pp|py|rb|rs|R|scala|scss|sh|slim|tex|tmpl|ts|txt|yaml|yml)$
 -   id: fix-encoding-pragma
     name: Fix python encoding pragma
     language: python
@@ -140,4 +140,4 @@
     description: This hook trims trailing whitespace.
     entry: trailing-whitespace-fixer
     language: python
-    files: \.(asciidoc|adoc|coffee|cpp|css|c|ejs|erb|h|haml|hh|hpp|hxx|html|in|jade|json|js|less|markdown|md|ml|mli|pp|py|rb|rs|R|scala|scss|sh|slim|tmpl|ts|txt|yaml|yml)$
+    files: \.(asciidoc|adoc|coffee|cpp|css|c|ejs|erb|groovy|h|haml|hh|hpp|hxx|html|in|jade|json|js|less|markdown|md|ml|mli|pp|py|rb|rs|R|scala|scss|sh|slim|tex|tmpl|ts|txt|yaml|yml)$


### PR DESCRIPTION
* Modifies the `end-of-file-fixer` and `trailing-whitespace` hooks to include .groovy and .tex (TeX/LaTeX) files.

We have some Groovy files as well as some LaTeX files that could benefit from whitespace fixing awesomeness!

@Lucas-C @asottile