### PR TITLE
Add forbid-new-submodules to hooks.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Add this to your `.pre-commit-config.yaml`
 - `fix-encoding-pragma` - Add `# -*- coding: utf-8 -*-` to the top of python files.
     - To remove the coding pragma pass `--remove` (useful in a python3-only codebase)
 - `flake8` - Run flake8 on your python files.
+- `forbid-new-submodules` - Prevent addition of new git submodules.
 - `name-tests-test` - Assert that files in tests/ end in `_test.py`.
     - Use `args: ['--django']` to match `test*.py` instead.
 - `pyflakes` - Run pyflakes on your python files.

--- a/hooks.yaml
+++ b/hooks.yaml
@@ -117,6 +117,12 @@
     entry: flake8
     language: python
     files: \.py$
+-   id: forbid-new-submodules
+    name: Forbid new submodules
+    language: python
+    entry: forbid-new-submodules
+    description: Prevent addition of new git submodules
+    files: ''
 -   id: name-tests-test
     name: Tests should end in _test.py
     description: This verifies that test files are named correctly

--- a/pre_commit_hooks/forbid_new_submodules.py
+++ b/pre_commit_hooks/forbid_new_submodules.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 from __future__ import unicode_literals
 
 from pre_commit_hooks.util import cmd_output
@@ -19,6 +20,7 @@ def main(argv=None):
             retv = 1
 
     if retv:
+        print()
         print('This commit introduces new submodules.')
         print('Did you unintentionally `git add .`?')
         print('To fix: git rm {thesubmodule}  # no trailing slash')

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
             'double-quote-string-fixer = pre_commit_hooks.string_fixer:main',
             'end-of-file-fixer = pre_commit_hooks.end_of_file_fixer:end_of_file_fixer',
             'fix-encoding-pragma = pre_commit_hooks.fix_encoding_pragma:main',
+            'forbid-new-submodules = pre_commit_hooks.forbid_new_submodules:main',
             'name-tests-test = pre_commit_hooks.tests_should_end_in_test:validate_files',
             'pretty-format-json = pre_commit_hooks.pretty_format_json:pretty_format_json',
             'requirements-txt-fixer = pre_commit_hooks.requirements_txt_fixer:fix_requirements_txt',


### PR DESCRIPTION
```
(virtualenv_run) [1] ckuehl@dev4-uswest1cdevc:~/pg/yelp-main$ gs
# On branch master
# Changes to be committed:
#   (use "git reset HEAD <file>..." to unstage)
#
#       modified:   .pre-commit-config.yaml
#       new file:   blah
#
(virtualenv_run) ckuehl@dev4-uswest1cdevc:~/pg/yelp-main$ gc
Forbid new submodules....................................................Failed
hookid: forbid-new-submodules

blah: new submodule introduced
This commit introduces new submodules.
Did you unintentionally `git add .`?
To fix: git rm {thesubmodule}  # no trailing slash
Also check .gitmodules
```