### PR TITLE
Fix test error "fatal: empty ident name (for <(null)>) not allowed"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ env: # These should match the tox env list
     - TOXENV=pypy
 install: pip install coveralls tox
 script: tox
-# Special snowflake.  Our tests depend on making real commits.
 before_install:
-  - git config --global user.name "Travis CI"
-  - git config --global user.email "user@example.com"
   # Install git-lfs for a test
   - './get-git-lfs.py && export PATH="/tmp/git-lfs:$PATH"'
 after_success:

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,11 @@ envlist = py27,py34,py35,pypy
 [testenv]
 deps = -rrequirements-dev.txt
 passenv = HOME HOMEPATH PROGRAMDATA
+setenv =
+    GIT_AUTHOR_NAME = "test"
+    GIT_COMMITTER_NAME = "test"
+    GIT_AUTHOR_EMAIL = "test@example.com"
+    GIT_COMMITTER_EMAIL = "test@example.com"
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}


### PR DESCRIPTION
This occurs when there is no global setting for git config options user.name and user.email

An example of the error shown below:
```
E           pre_commit.util.CalledProcessError: Command: ('/usr/bin/git', 'commit', '-m', 'init', '--allow-empty')
E           Return code: 128
E           Expected return code: 0
E           Output: (none)
E           Errors:
E
E               *** Please tell me who you are.
E
E               Run
E
E                 git config --global user.email "you@example.com"
E                 git config --global user.name "Your Name"
E
E               to set your account's default identity.
E               Omit --global to set the identity only in this repository.
E
E               fatal: empty ident name (for <(null)>) not allowed
```