### PR TITLE
Use open built-in to open files in hooks

### DIFF
--- a/pre_commit_hooks/autopep8_wrapper.py
+++ b/pre_commit_hooks/autopep8_wrapper.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import io
 import sys
 
 import autopep8
@@ -14,12 +13,12 @@ def main(argv=None):
 
     retv = 0
     for filename in args.files:
-        original_contents = io.open(filename).read()
+        original_contents = open(filename).read()
         new_contents = autopep8.fix_code(original_contents, args)
         if original_contents != new_contents:
             print('Fixing {0}'.format(filename))
             retv = 1
-            with io.open(filename, 'w') as output_file:
+            with open(filename, 'w') as output_file:
                 output_file.write(new_contents)
 
     return retv

--- a/pre_commit_hooks/check_docstring_first.py
+++ b/pre_commit_hooks/check_docstring_first.py
@@ -57,7 +57,7 @@ def main(argv=None):
     retv = 0
 
     for filename in args.filenames:
-        contents = io.open(filename).read()
+        contents = open(filename).read()
         retv |= check_docstring_first(contents, filename=filename)
 
     return retv

--- a/pre_commit_hooks/check_xml.py
+++ b/pre_commit_hooks/check_xml.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import argparse
-import io
 import sys
 import xml.sax
 
@@ -16,7 +15,7 @@ def check_xml(argv=None):
     retval = 0
     for filename in args.filenames:
         try:
-            with io.open(filename, 'rb') as xml_file:
+            with open(filename, 'rb') as xml_file:
                 xml.sax.parse(xml_file, xml.sax.ContentHandler())
         except xml.sax.SAXException as exc:
             print('{0}: Failed to xml parse ({1})'.format(filename, exc))

--- a/pre_commit_hooks/string_fixer.py
+++ b/pre_commit_hooks/string_fixer.py
@@ -32,7 +32,7 @@ def get_line_offsets_by_line_no(src):
 
 
 def fix_strings(filename):
-    contents = io.open(filename).read()
+    contents = open(filename).read()
     line_offsets = get_line_offsets_by_line_no(contents)
 
     # Basically a mutable string
@@ -52,7 +52,7 @@ def fix_strings(filename):
 
     new_contents = ''.join(splitcontents)
     if contents != new_contents:
-        with io.open(filename, 'w') as write_handle:
+        with open(filename, 'w') as write_handle:
             write_handle.write(new_contents)
         return 1
     else:

--- a/testing/util.py
+++ b/testing/util.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import io
 import os.path
 
 
@@ -14,5 +13,5 @@ def get_resource_path(path):
 
 def write_file(filename, contents):
     """Hax because coveragepy chokes on nested context managers."""
-    with io.open(filename, 'w', newline='') as file_obj:
+    with open(filename, 'w', newline='') as file_obj:
         file_obj.write(contents)

--- a/tests/readme_test.py
+++ b/tests/readme_test.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import io
-
 import yaml
 
 
 def test_readme_contains_all_hooks():
-    readme_contents = io.open('README.md').read()
-    hooks = yaml.load(io.open('hooks.yaml').read())
+    readme_contents = open('README.md').read()
+    hooks = yaml.load(open('hooks.yaml').read())
     for hook in hooks:
         assert '`{0}`'.format(hook['id']) in readme_contents


### PR DESCRIPTION
* This makes Python 3 not raise UnicodeDecodeError when reading files:

```
...

Fix double quoted strings...............................................................................................................................................................Failed
hookid: double-quote-string-fixer

Traceback (most recent call last):
  File "/pre-commit/.pre-commit/repok371rkyn/py_env-default/bin/double-quote-string-fixer", line 11, in <module>
    load_entry_point('pre-commit-hooks==0.6.1', 'console_scripts', 'double-quote-string-fixer')()
  File "/pre-commit/.pre-commit/repok371rkyn/py_env-default/lib/python3.5/site-packages/pre_commit_hooks/string_fixer.py", line 70, in main
    return_value = fix_strings(filename)
  File "/pre-commit/.pre-commit/repok371rkyn/py_env-default/lib/python3.5/site-packages/pre_commit_hooks/string_fixer.py", line 35, in fix_strings
    contents = io.open(filename).read()
  File "/pre-commit/.pre-commit/repok371rkyn/py_env-default/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 10776: ordinal not in range(128)

...

Debug Statements (Python)...............................................................................................................................................................Failed
hookid: debug-statements

Traceback (most recent call last):
  File "/pre-commit/.pre-commit/repok371rkyn/py_env-default/bin/debug-statement-hook", line 11, in <module>
    load_entry_point('pre-commit-hooks==0.6.1', 'console_scripts', 'debug-statement-hook')()
  File "/pre-commit/.pre-commit/repok371rkyn/py_env-default/lib/python3.5/site-packages/pre_commit_hooks/debug_statement_hook.py", line 69, in debug_statement_hook
    retv |= check_file_for_debug_statements(filename)
  File "/pre-commit/.pre-commit/repok371rkyn/py_env-default/lib/python3.5/site-packages/pre_commit_hooks/debug_statement_hook.py", line 38, in check_file_for_debug_statements
    ast_obj = ast.parse(open(filename).read(), filename=filename)
  File "/pre-commit/.pre-commit/repok371rkyn/py_env-default/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 10776: ordinal not in range(128)

...

Check docstring is first................................................................................................................................................................Failed
hookid: check-docstring-first

Traceback (most recent call last):
  File "/pre-commit/.pre-commit/repok371rkyn/py_env-default/bin/check-docstring-first", line 11, in <module>
    load_entry_point('pre-commit-hooks==0.6.1', 'console_scripts', 'check-docstring-first')()
  File "/pre-commit/.pre-commit/repok371rkyn/py_env-default/lib/python3.5/site-packages/pre_commit_hooks/check_docstring_first.py", line 60, in main
    contents = io.open(filename).read()
  File "/pre-commit/.pre-commit/repok371rkyn/py_env-default/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 10776: ordinal not in range(128)

...
```