### PR TITLE
Add flag to detect-aws-credentials to allow missing keys

### DIFF
--- a/pre_commit_hooks/detect_aws_credentials.py
+++ b/pre_commit_hooks/detect_aws_credentials.py
@@ -95,6 +95,12 @@ def main(argv=None):
             'secret keys from'
         )
     )
+    parser.add_argument(
+        '--allow-missing-credentials',
+        dest='allow_missing_credentials',
+        action='store_true',
+        help='Allow hook to pass when no credentials are detected.'
+    )
     args = parser.parse_args(argv)
 
     credential_files = set(args.credential_files)
@@ -110,6 +116,9 @@ def main(argv=None):
     # Secrets might be part of environment variables, so add such secrets to
     # the set of keys.
     keys |= get_aws_secrets_from_env()
+
+    if not keys and args.allow_missing_credentials:
+        return 0
 
     if not keys:
         print(

--- a/tests/detect_aws_credentials_test.py
+++ b/tests/detect_aws_credentials_test.py
@@ -130,3 +130,17 @@ def test_non_existent_credentials(mock_secrets_env, mock_secrets_file, capsys):
         'and environment variables.\nPlease ensure you have the '
         'correct setting for --credentials-file\n'
     )
+
+
+@patch('pre_commit_hooks.detect_aws_credentials.get_aws_secrets_from_file')
+@patch('pre_commit_hooks.detect_aws_credentials.get_aws_secrets_from_env')
+def test_non_existent_credentials_with_allow_flag(mock_secrets_env, mock_secrets_file):
+    """Test behavior with no configured AWS secrets and flag to allow when missing."""
+    mock_secrets_env.return_value = set()
+    mock_secrets_file.return_value = set()
+    ret = main((
+        get_resource_path('aws_config_without_secrets.ini'),
+        "--credentials-file=testing/resources/credentailsfilethatdoesntexist",
+        "--allow-missing-credentials"
+    ))
+    assert ret == 0


### PR DESCRIPTION
In the event that there exists no configuration for AWS credentials and
they are not exported in to the current environment, a flag may be
passed to allow exiting the hook successfully.

Resolves #174

Signed-off-by: Mike Fiedler <miketheman@gmail.com>