### PR TITLE
Change `sha` in readme to be a real value

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See also: https://github.com/pre-commit/pre-commit
 Add this to your `.pre-commit-config.yaml`
 
     -   repo: git://github.com/pre-commit/pre-commit-hooks
-        sha: ''  # Use the sha you want to point at
+        sha: v0.7.1  # Use the ref you want to point at
         hooks:
         -   id: trailing-whitespace
         # -   id: ...


### PR DESCRIPTION
I noticed in our traffic on pre-commit/pre-commit that there were a lot of hits to [this issue](https://github.com/pre-commit/pre-commit/issues/366) presumably due to copy pasting from this readme.

This should reduce frustration in that regard (we'll have to remember to update this whenever bumping the version).