### PR TITLE
Handling default django test filename of "tests.py"

### DIFF
--- a/pre_commit_hooks/tests_should_end_in_test.py
+++ b/pre_commit_hooks/tests_should_end_in_test.py
@@ -16,7 +16,7 @@ def validate_files(argv=None):
     args = parser.parse_args(argv)
 
     retcode = 0
-    test_name_pattern = 'test_.*.py' if args.django else '.*_test.py'
+    test_name_pattern = 'test.*.py' if args.django else '.*_test.py'
     for filename in args.filenames:
         base = basename(filename)
         if (

--- a/tests/tests_should_end_in_test_test.py
+++ b/tests/tests_should_end_in_test_test.py
@@ -12,7 +12,7 @@ def test_validate_files_one_fails():
 
 
 def test_validate_files_django_all_pass():
-    ret = validate_files(['--django', 'test_foo.py', 'test_bar.py', 'tests/test_baz.py'])
+    ret = validate_files(['--django', 'tests.py', 'test_foo.py', 'test_bar.py', 'tests/test_baz.py'])
     assert ret == 0
 
 


### PR DESCRIPTION
#181 - Fix to restore regex to handle tests.py, the default Django test format