### PR TITLE
no-commit-to-branch: Fixed manifest validation issue

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -133,7 +133,6 @@
     name: "Don't commit to branch"
     entry: no-commit-to-branch
     language: python
-    files: .*
     always_run: true
 -   id: pyflakes
     name: Pyflakes (DEPRECATED, use flake8)

--- a/hooks.yaml
+++ b/hooks.yaml
@@ -133,7 +133,6 @@
     name: "Don't commit to branch"
     entry: no-commit-to-branch
     language: python
-    files: .*
     always_run: true
 -   id: pyflakes
     name: Pyflakes (DEPRECATED, use flake8)


### PR DESCRIPTION
Since https://github.com/pre-commit/pre-commit has changed to it's now schema validation the no-commit-to-branch check failed. The `files` attribute should not be present when `always_run` is `true`