### PR TITLE
Force setuptools < 36.0.0 to avoid simplejson/six error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
 
     packages=find_packages('.', exclude=('tests*', 'testing*')),
     install_requires=[
+        'setuptools<36.0.0',
         # quickfix to prevent pep8 conflicts
         'flake8!=2.5.3',
         'argparse',


### PR DESCRIPTION
With the latest setuptools, pre-commit run fails with the following

```
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: Command: ('/root/.pre-commit/repoDFpupm/py_env-default/bin/python2.7', u'/root/.pre-commit/repoDFpupm/py_env-default/bin/pip', 'install', '.')
Return code: 1
Expected return code: 0
Output:
    Processing /root/.pre-commit/repoDFpupm
    Collecting flake8!=2.5.3 (from pre-commit-hooks==0.7.1)
      Downloading flake8-3.3.0-py2.py3-none-any.whl (66kB)
    Collecting autopep8>=1.1 (from pre-commit-hooks==0.7.1)
      Downloading autopep8-1.3.2-py2.py3-none-any.whl (42kB)
    Collecting pyyaml (from pre-commit-hooks==0.7.1)
    Collecting simplejson (from pre-commit-hooks==0.7.1)
      Downloading simplejson-3.10.0.tar.gz (77kB)
    Collecting six (from pre-commit-hooks==0.7.1)
      Downloading six-1.10.0-py2.py3-none-any.whl
    Collecting enum34; python_version < "3.4" (from flake8!=2.5.3->pre-commit-hooks==0.7.1)
      Downloading enum34-1.1.6-py2-none-any.whl
    Collecting configparser; python_version < "3.2" (from flake8!=2.5.3->pre-commit-hooks==0.7.1)
      Downloading configparser-3.5.0.tar.gz
    Collecting pyflakes<1.6.0,>=1.5.0 (from flake8!=2.5.3->pre-commit-hooks==0.7.1)
      Downloading pyflakes-1.5.0-py2.py3-none-any.whl (225kB)
    Collecting mccabe<0.7.0,>=0.6.0 (from flake8!=2.5.3->pre-commit-hooks==0.7.1)
      Downloading mccabe-0.6.1-py2.py3-none-any.whl
    Collecting pycodestyle<2.4.0,>=2.0.0 (from flake8!=2.5.3->pre-commit-hooks==0.7.1)
      Downloading pycodestyle-2.3.1-py2.py3-none-any.whl (45kB)
    Building wheels for collected packages: simplejson, configparser
      Running setup.py bdist_wheel for simplejson: started
      Running setup.py bdist_wheel for simplejson: finished with status 'error'
      Complete output from command /root/.pre-commit/repoDFpupm/py_env-default/bin/python2.7 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-Kn9zYg/simplejson/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpjj9RY8pip-wheel- --python-tag cp27:
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build/lib.linux-x86_64-2.7
      creating build/lib.linux-x86_64-2.7/simplejson
      copying simplejson/encoder.py -> build/lib.linux-x86_64-2.7/simplejson
      copying simplejson/ordered_dict.py -> build/lib.linux-x86_64-2.7/simplejson
      copying simplejson/scanner.py -> build/lib.linux-x86_64-2.7/simplejson
      copying simplejson/decoder.py -> build/lib.linux-x86_64-2.7/simplejson
      copying simplejson/compat.py -> build/lib.linux-x86_64-2.7/simplejson
      copying simplejson/tool.py -> build/lib.linux-x86_64-2.7/simplejson
      copying simplejson/__init__.py -> build/lib.linux-x86_64-2.7/simplejson
      creating build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_decode.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_bitsize_int_as_string.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_speedups.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_default.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_errors.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_pass2.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_namedtuple.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_item_sort_key.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_check_circular.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_raw_json.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_for_json.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_float.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_tuple.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_subclass.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_unicode.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_dump.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_bigint_as_string.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_encode_basestring_ascii.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_decimal.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_encode_for_html.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_str_subclass.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_pass1.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_iterable.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_separators.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/__init__.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_tool.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_recursion.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_scanstring.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_fail.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_pass3.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      copying simplejson/tests/test_indent.py -> build/lib.linux-x86_64-2.7/simplejson/tests
      running build_ext
      building 'simplejson._speedups' extension
      creating build/temp.linux-x86_64-2.7
      creating build/temp.linux-x86_64-2.7/simplejson
      gcc -pthread -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/usr/local/include/python2.7 -c simplejson/_speedups.c -o build/temp.linux-x86_64-2.7/simplejson/_speedups.o
      unable to execute 'gcc': No such file or directory
      ***************************************************************************
      WARNING: The C extension could not be compiled, speedups are not enabled.
      Failure information, if any, is above.
      I'm retrying the build without the C extension now.
      ***************************************************************************
      running bdist_wheel
      running build
      running build_py
      creating build/lib
      creating build/lib/simplejson
      copying simplejson/encoder.py -> build/lib/simplejson
      copying simplejson/ordered_dict.py -> build/lib/simplejson
      copying simplejson/scanner.py -> build/lib/simplejson
      copying simplejson/decoder.py -> build/lib/simplejson
      copying simplejson/compat.py -> build/lib/simplejson
      copying simplejson/tool.py -> build/lib/simplejson
      copying simplejson/__init__.py -> build/lib/simplejson
      creating build/lib/simplejson/tests
      copying simplejson/tests/test_decode.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_bitsize_int_as_string.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_speedups.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_default.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_errors.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_pass2.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_namedtuple.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_item_sort_key.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_check_circular.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_raw_json.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_for_json.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_float.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_tuple.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_subclass.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_unicode.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_dump.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_bigint_as_string.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_encode_basestring_ascii.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_decimal.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_encode_for_html.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_str_subclass.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_pass1.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_iterable.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_separators.py -> build/lib/simplejson/tests
      copying simplejson/tests/__init__.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_tool.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_recursion.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_scanstring.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_fail.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_pass3.py -> build/lib/simplejson/tests
      copying simplejson/tests/test_indent.py -> build/lib/simplejson/tests
      installing to build/bdist.linux-x86_64/wheel
      running install
      running install_lib
      creating build/bdist.linux-x86_64
      creating build/bdist.linux-x86_64/wheel
      creating build/bdist.linux-x86_64/wheel/simplejson
      copying build/lib/simplejson/encoder.py -> build/bdist.linux-x86_64/wheel/simplejson
      copying build/lib/simplejson/ordered_dict.py -> build/bdist.linux-x86_64/wheel/simplejson
      copying build/lib/simplejson/scanner.py -> build/bdist.linux-x86_64/wheel/simplejson
      copying build/lib/simplejson/decoder.py -> build/bdist.linux-x86_64/wheel/simplejson
      copying build/lib/simplejson/compat.py -> build/bdist.linux-x86_64/wheel/simplejson
      copying build/lib/simplejson/tool.py -> build/bdist.linux-x86_64/wheel/simplejson
      creating build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_decode.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_bitsize_int_as_string.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_speedups.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_default.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_errors.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_pass2.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_namedtuple.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_item_sort_key.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_check_circular.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_raw_json.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_for_json.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_float.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_tuple.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_subclass.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_unicode.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_dump.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_bigint_as_string.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_encode_basestring_ascii.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_decimal.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_encode_for_html.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_str_subclass.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_pass1.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_iterable.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_separators.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/__init__.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_tool.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_recursion.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_scanstring.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_fail.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_pass3.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/tests/test_indent.py -> build/bdist.linux-x86_64/wheel/simplejson/tests
      copying build/lib/simplejson/__init__.py -> build/bdist.linux-x86_64/wheel/simplejson
      running install_egg_info
      running egg_info
      writing simplejson.egg-info/PKG-INFO
      writing top-level names to simplejson.egg-info/top_level.txt
      writing dependency_links to simplejson.egg-info/dependency_links.txt
      reading manifest file 'simplejson.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      writing manifest file 'simplejson.egg-info/SOURCES.txt'
      Copying simplejson.egg-info to build/bdist.linux-x86_64/wheel/simplejson-3.10.0-py2.7.egg-info
      running install_scripts
      Traceback (most recent call last):
        File "<string>", line 1, in <module>
        File "/tmp/pip-build-Kn9zYg/simplejson/setup.py", line 121, in <module>
          run_setup(False)
        File "/tmp/pip-build-Kn9zYg/simplejson/setup.py", line 108, in run_setup
          **kw)
        File "/usr/local/lib/python2.7/distutils/core.py", line 151, in setup
          dist.run_commands()
        File "/usr/local/lib/python2.7/distutils/dist.py", line 953, in run_commands
          self.run_command(cmd)
        File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
          cmd_obj.run()
        File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/wheel/bdist_wheel.py", line 215, in run
          self.run_command('install')
        File "/usr/local/lib/python2.7/distutils/cmd.py", line 326, in run_command
          self.distribution.run_command(command)
        File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
          cmd_obj.run()
        File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/command/install.py", line 61, in run
          return orig.install.run(self)
        File "/usr/local/lib/python2.7/distutils/command/install.py", line 575, in run
          self.run_command(cmd_name)
        File "/usr/local/lib/python2.7/distutils/cmd.py", line 326, in run_command
          self.distribution.run_command(command)
        File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
          cmd_obj.run()
        File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/command/install_scripts.py", line 17, in run
          import setuptools.command.easy_install as ei
        File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 49, in <module>
          from setuptools.py27compat import rmtree_safe
        File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/py27compat.py", line 7, in <module>
          import six
      ImportError: No module named six

      ----------------------------------------
      Running setup.py clean for simplejson
      Running setup.py bdist_wheel for configparser: started
      Running setup.py bdist_wheel for configparser: finished with status 'error'
      Complete output from command /root/.pre-commit/repoDFpupm/py_env-default/bin/python2.7 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-Kn9zYg/configparser/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpx2UVJJpip-wheel- --python-tag cp27:
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build/lib
      copying src/configparser.py -> build/lib
      creating build/lib/backports
      copying src/backports/__init__.py -> build/lib/backports
      creating build/lib/backports/configparser
      copying src/backports/configparser/helpers.py -> build/lib/backports/configparser
      copying src/backports/configparser/__init__.py -> build/lib/backports/configparser
      running egg_info
      writing src/configparser.egg-info/PKG-INFO
      writing namespace_packages to src/configparser.egg-info/namespace_packages.txt
      writing top-level names to src/configparser.egg-info/top_level.txt
      writing dependency_links to src/configparser.egg-info/dependency_links.txt
      reading manifest file 'src/configparser.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      writing manifest file 'src/configparser.egg-info/SOURCES.txt'
      installing to build/bdist.linux-x86_64/wheel
      running install
      running install_lib
      copying configparser.py -> build/bdist.linux-x86_64/wheel
      Skipping installation of build/bdist.linux-x86_64/wheel/backports/__init__.py (namespace package)
      copying backports/configparser/helpers.py -> build/bdist.linux-x86_64/wheel/backports/configparser
      copying backports/configparser/__init__.py -> build/bdist.linux-x86_64/wheel/backports/configparser
      running install_egg_info
      Copying src/configparser.egg-info to build/bdist.linux-x86_64/wheel/configparser-3.5.0-py2.7.egg-info
      Installing build/bdist.linux-x86_64/wheel/configparser-3.5.0-py2.7-nspkg.pth
      running install_scripts
      Traceback (most recent call last):
        File "<string>", line 1, in <module>
        File "/tmp/pip-build-Kn9zYg/configparser/setup.py", line 63, in <module>
          'Topic :: Software Development :: Libraries :: Python Modules',
        File "/usr/local/lib/python2.7/distutils/core.py", line 151, in setup
          dist.run_commands()
        File "/usr/local/lib/python2.7/distutils/dist.py", line 953, in run_commands
          self.run_command(cmd)
        File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
          cmd_obj.run()
        File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/wheel/bdist_wheel.py", line 215, in run
          self.run_command('install')
        File "/usr/local/lib/python2.7/distutils/cmd.py", line 326, in run_command
          self.distribution.run_command(command)
        File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
          cmd_obj.run()
        File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/command/install.py", line 61, in run
          return orig.install.run(self)
        File "/usr/local/lib/python2.7/distutils/command/install.py", line 575, in run
          self.run_command(cmd_name)
        File "/usr/local/lib/python2.7/distutils/cmd.py", line 326, in run_command
          self.distribution.run_command(command)
        File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
          cmd_obj.run()
        File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/command/install_scripts.py", line 17, in run
          import setuptools.command.easy_install as ei
        File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 49, in <module>
          from setuptools.py27compat import rmtree_safe
        File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/py27compat.py", line 7, in <module>
          import six
      ImportError: No module named six

      ----------------------------------------
      Running setup.py clean for configparser
    Failed to build simplejson configparser
    Installing collected packages: enum34, configparser, pyflakes, mccabe, pycodestyle, flake8, autopep8, pyyaml, simplejson, six, pre-commit-hooks
      Running setup.py install for configparser: started
        Running setup.py install for configparser: finished with status 'error'
        Complete output from command /root/.pre-commit/repoDFpupm/py_env-default/bin/python2.7 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-Kn9zYg/configparser/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-LnaZWh-record/install-record.txt --single-version-externally-managed --compile --install-headers /root/.pre-commit/repoDFpupm/py_env-default/include/site/python2.7/configparser:
        running install
        running build
        running build_py
        creating build
        creating build/lib
        copying src/configparser.py -> build/lib
        creating build/lib/backports
        copying src/backports/__init__.py -> build/lib/backports
        creating build/lib/backports/configparser
        copying src/backports/configparser/helpers.py -> build/lib/backports/configparser
        copying src/backports/configparser/__init__.py -> build/lib/backports/configparser
        running egg_info
        writing src/configparser.egg-info/PKG-INFO
        writing namespace_packages to src/configparser.egg-info/namespace_packages.txt
        writing top-level names to src/configparser.egg-info/top_level.txt
        writing dependency_links to src/configparser.egg-info/dependency_links.txt
        reading manifest file 'src/configparser.egg-info/SOURCES.txt'
        reading manifest template 'MANIFEST.in'
        writing manifest file 'src/configparser.egg-info/SOURCES.txt'
        running install_lib
        copying configparser.py -> /root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages
        Skipping installation of /root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/backports/__init__.py (namespace package)
        copying backports/configparser/helpers.py -> /root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/backports/configparser
        copying backports/configparser/__init__.py -> /root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/backports/configparser
        byte-compiling /root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/configparser.py to configparser.pyc
        byte-compiling /root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/backports/configparser/helpers.py to helpers.pyc
        byte-compiling /root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/backports/configparser/__init__.py to __init__.pyc
        running install_egg_info
        Copying src/configparser.egg-info to /root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/configparser-3.5.0-py2.7.egg-info
        Installing /root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/configparser-3.5.0-py2.7-nspkg.pth
        running install_scripts
        Traceback (most recent call last):
          File "<string>", line 1, in <module>
          File "/tmp/pip-build-Kn9zYg/configparser/setup.py", line 63, in <module>
            'Topic :: Software Development :: Libraries :: Python Modules',
          File "/usr/local/lib/python2.7/distutils/core.py", line 151, in setup
            dist.run_commands()
          File "/usr/local/lib/python2.7/distutils/dist.py", line 953, in run_commands
            self.run_command(cmd)
          File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
            cmd_obj.run()
          File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/command/install.py", line 61, in run
            return orig.install.run(self)
          File "/usr/local/lib/python2.7/distutils/command/install.py", line 575, in run
            self.run_command(cmd_name)
          File "/usr/local/lib/python2.7/distutils/cmd.py", line 326, in run_command
            self.distribution.run_command(command)
          File "/usr/local/lib/python2.7/distutils/dist.py", line 972, in run_command
            cmd_obj.run()
          File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/command/install_scripts.py", line 17, in run
            import setuptools.command.easy_install as ei
          File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 49, in <module>
            from setuptools.py27compat import rmtree_safe
          File "/root/.pre-commit/repoDFpupm/py_env-default/lib/python2.7/site-packages/setuptools/py27compat.py", line 7, in <module>
            import six
        ImportError: No module named six

        ----------------------------------------

Errors:
      Failed building wheel for simplejson
      Failed building wheel for configparser
    Command "/root/.pre-commit/repoDFpupm/py_env-default/bin/python2.7 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-Kn9zYg/configparser/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-LnaZWh-record/install-record.txt --single-version-externally-managed --compile --install-headers /root/.pre-commit/repoDFpupm/py_env-default/include/site/python2.7/configparser" failed with error code 1 in /tmp/pip-build-Kn9zYg/configparser/
```