### PR TITLE
edit detect_private_key to ignore directories

### DIFF
--- a/pre_commit_hooks/detect_private_key.py
+++ b/pre_commit_hooks/detect_private_key.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import argparse
+import os
 import sys
 
 BLACKLIST = [
@@ -19,6 +20,8 @@ def detect_private_key(argv=None):
     private_key_files = []
 
     for filename in args.filenames:
+        if os.path.isdir(filename):
+            continue
         with open(filename, 'rb') as f:
             content = f.read()
             if any(line in content for line in BLACKLIST):


### PR DESCRIPTION
Currently if given a directory, detect_private_key tries to open it as a file and spews errors as a result. The behavior of this should either recursively search the directory or ignore the directory instead. This code ignores the directory.