### PR TITLE
Make check-symlinks 0.15.0 compatible

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -63,6 +63,7 @@
     language: python
     # Match all files
     files: ''
+    types: [symlink]
 -   id: check-xml
     name: Check Xml
     description: This hook checks xml files for parseable syntax.

--- a/hooks.yaml
+++ b/hooks.yaml
@@ -63,6 +63,7 @@
     language: python
     # Match all files
     files: ''
+    types: [symlink]
 -   id: check-xml
     name: Check Xml
     description: This hook checks xml files for parseable syntax.


### PR DESCRIPTION
As outlined in https://github.com/pre-commit/pre-commit/pull/551, this hook will become nonfunctional (without this patch) in pre-commit 0.15.0