### PR TITLE
Add mypy pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -191,6 +191,15 @@
     # for backward compatibility
     files: ''
     minimum_pre_commit_version: 0.15.0
+-   id: mypy
+    name: mypy
+    description: This hook runs mypy.
+    entry: mypy
+    language: python
+    types: [python]
+    # for backward compatibility
+    files: ''
+    minimum_pre_commit_version: 0.15.0
 -   id: name-tests-test
     name: Tests should end in _test.py
     description: This verifies that test files are named correctly

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Add this to your `.pre-commit-config.yaml`
 - `file-contents-sorter` - Sort the lines in specified files (defaults to alphabetical). You must provide list of target files as input to it. Note that this hook WILL remove blank lines and does NOT respect any comments.
 - `flake8` - Run flake8 on your python files.
 - `forbid-new-submodules` - Prevent addition of new git submodules.
+- `mypy` - Run mypy on your python files.
+    - Use `files: ^my_package/.+\.py$` to exclude test and other files from being checked.
+    - Use `args: ['--config-file', 'mypy-pre-commit.ini']` to use a custom mypy configuration for this pre-commit hook.
 - `name-tests-test` - Assert that files in tests/ end in `_test.py`.
     - Use `args: ['--django']` to match `test*.py` instead.
 - `no-commit-to-branch` - Protect specific branches from direct checkins.

--- a/hooks.yaml
+++ b/hooks.yaml
@@ -130,6 +130,12 @@
     entry: upgrade-your-pre-commit-version
     files: ''
     minimum_pre_commit_version: 0.15.0
+-   id: mypy
+    language: system
+    name: upgrade-your-pre-commit-version
+    entry: upgrade-your-pre-commit-version
+    files: ''
+    minimum_pre_commit_version: 0.15.0
 -   id: name-tests-test
     language: system
     name: upgrade-your-pre-commit-version


### PR DESCRIPTION
The idea here is to use it primarily to make sure Python code is annotated properly. An example minimal configuration could look like this:

    [mypy]
    check_untyped_defs = True
    disallow_untyped_calls = False
    disallow_untyped_defs = True
    follow_imports = silent
    ignore_missing_imports = True

We've been using this hook internally and it works well. I've replaced the internal hook by pointing to my pre-commit-hooks fork and it continued to work.