### PR TITLE
handle file reading exceptions

### DIFF
--- a/pre_commit_hooks/debug_statement_hook.py
+++ b/pre_commit_hooks/debug_statement_hook.py
@@ -42,6 +42,12 @@ def check_file_for_debug_statements(filename):
         print('\t' + traceback.format_exc().replace('\n', '\n\t'))
         print()
         return 1
+    except Exception:
+        print('{} - Caught exception while reading file'.format(filename))
+        print()
+        print('\t' + traceback.format_exc().replace('\n', '\n\t'))
+        print()
+        return 1
     visitor = ImportStatementParser()
     visitor.visit(ast_obj)
     if visitor.debug_import_statements:

--- a/pre_commit_hooks/string_fixer.py
+++ b/pre_commit_hooks/string_fixer.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import argparse
 import io
 import tokenize
+import traceback
 
 
 double_quote_starts = tuple(s for s in tokenize.single_quoted if '"' in s)
@@ -32,7 +33,14 @@ def get_line_offsets_by_line_no(src):
 
 
 def fix_strings(filename):
-    contents = io.open(filename).read()
+    try:
+        contents = io.open(filename).read()
+    except Exception:
+        print('{} - Caught exception while reading file'.format(filename))
+        print()
+        print('\t' + traceback.format_exc().replace('\n', '\n\t'))
+        print()
+        return 1
     line_offsets = get_line_offsets_by_line_no(contents)
 
     # Basically a mutable string


### PR DESCRIPTION
I was going to just open an issue, but this turned out to be a relatively straightforward fix. See issue below; this PR ensures the filename is attached to the given errors.

Original issue: "Uncaught file-read exceptions hide filename from error message"

When `debug-statements` or `double-quote-string-fixer` fail to unicode decode a file, not even the filename is shown in the error output. More generally, any Exception being raised during parsing would lead to this behavior.

```
Debug Statements (Python)................................................Failed
hookid: debug-statements

Traceback (most recent call last):
  File "/Users/kevin/.pre-commit/repow04yynsa/py_env-python3.6/bin/debug-statement-hook", line 11, in <module>
    load_entry_point('pre-commit-hooks==0.9.1', 'console_scripts', 'debug-statement-hook')()
  File "/Users/kevin/.pre-commit/repow04yynsa/py_env-python3.6/lib/python3.6/site-packages/pre_commit_hooks/debug_statement_hook.py", line 69, in debug_statement_hook
    retv |= check_file_for_debug_statements(filename)
  File "/Users/kevin/.pre-commit/repow04yynsa/py_env-python3.6/lib/python3.6/site-packages/pre_commit_hooks/debug_statement_hook.py", line 38, in check_file_for_debug_statements
    ast_obj = ast.parse(open(filename).read(), filename=filename)
  File "/Users/kevin/.pre-commit/repow04yynsa/py_env-python3.6/bin/../lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf3 in position 55: invalid continuation byte

Fix double quoted strings................................................Failed
hookid: double-quote-string-fixer

Traceback (most recent call last):
  File "/Users/kevin/.pre-commit/repow04yynsa/py_env-python3.6/bin/double-quote-string-fixer", line 11, in <module>
    load_entry_point('pre-commit-hooks==0.9.1', 'console_scripts', 'double-quote-string-fixer')()
  File "/Users/kevin/.pre-commit/repow04yynsa/py_env-python3.6/lib/python3.6/site-packages/pre_commit_hooks/string_fixer.py", line 70, in main
    return_value = fix_strings(filename)
  File "/Users/kevin/.pre-commit/repow04yynsa/py_env-python3.6/lib/python3.6/site-packages/pre_commit_hooks/string_fixer.py", line 35, in fix_strings
    contents = io.open(filename).read()
  File "/Users/kevin/.pre-commit/repow04yynsa/py_env-python3.6/bin/../lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf3 in position 55: invalid continuation byte
```