### PR TITLE
Fix trailing-whitespace on macos for non-utf8 files

### DIFF
--- a/pre_commit_hooks/trailing_whitespace_fixer.py
+++ b/pre_commit_hooks/trailing_whitespace_fixer.py
@@ -4,8 +4,6 @@ import argparse
 import os
 import sys
 
-from pre_commit_hooks.util import cmd_output
-
 
 def _fix_file(filename, is_markdown):
     with open(filename, mode='rb') as file_processed:
@@ -50,10 +48,6 @@ def fix_trailing_whitespace(argv=None):
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)
 
-    bad_whitespace_files = cmd_output(
-        'grep', '-l', '[[:space:]]$', *args.filenames, retcode=None
-    ).strip().splitlines()
-
     md_args = args.markdown_linebreak_ext
     if '' in md_args:
         parser.error('--markdown-linebreak-ext requires a non-empty argument')
@@ -73,11 +67,11 @@ def fix_trailing_whitespace(argv=None):
             )
 
     return_code = 0
-    for bad_whitespace_file in bad_whitespace_files:
-        _, extension = os.path.splitext(bad_whitespace_file.lower())
+    for filename in args.filenames:
+        _, extension = os.path.splitext(filename.lower())
         md = all_markdown or extension in md_exts
-        if _fix_file(bad_whitespace_file, md):
-            print('Fixing {}'.format(bad_whitespace_file))
+        if _fix_file(filename, md):
+            print('Fixing {}'.format(filename))
             return_code = 1
     return return_code
 


### PR DESCRIPTION
`grep` isn't portable so I removed it as well.  This probably makes this hook *slightly* slower as well.