### PR TITLE
Add print-message pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ Add this to your `.pre-commit-config.yaml`
     - `--indent ...` - Control the indentation (either a number for a number of spaces or a string of whitespace).  Defaults to 4 spaces.
     - `--no-sort-keys` - when autofixing, retain the original key ordering (instead of sorting the keys)
     - `--top-keys comma,separated,keys` - Keys to keep at the top of mappings.
+- `print-message` - Print a message and optionally fail when triggered.
+    - `--message ...` - The message to print.
+    - `--fail` - Whether to fail the pre-commit check.
 - `requirements-txt-fixer` - Sorts entries in requirements.txt
 - `sort-simple-yaml` - Sorts simple YAML files which consist only of top-level keys, preserving comments and blocks.
 - `trailing-whitespace` - Trims trailing whitespace.

--- a/pre_commit_hooks/print_message.py
+++ b/pre_commit_hooks/print_message.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+
+import argparse
+import sys
+
+default_message = 'You failed to provide a message to the `print_message` pre-commit hook via the -m or --message arg'
+
+
+def main(argv=[]):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-m',
+        '--message',
+        dest='message',
+        default=default_message,
+        help='the message to display when this pre-commit hook is triggered',
+    )
+    parser.add_argument(
+        '-f',
+        '--fail',
+        dest='outcome',
+        action='store_const',
+        const=1,
+        default=0,
+        help='use this flag to make the pre-commit hook fail if it is triggered',
+    )
+    args = parser.parse_args(argv)
+    print(args.message)
+    return args.outcome
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
             'mixed-line-ending = pre_commit_hooks.mixed_line_ending:main',
             'name-tests-test = pre_commit_hooks.tests_should_end_in_test:validate_files',
             'no-commit-to-branch = pre_commit_hooks.no_commit_to_branch:main',
+            'print-message = pre_commit_hooks.print_message:main',
             'pretty-format-json = pre_commit_hooks.pretty_format_json:pretty_format_json',
             'requirements-txt-fixer = pre_commit_hooks.requirements_txt_fixer:fix_requirements_txt',
             'sort-simple-yaml = pre_commit_hooks.sort_simple_yaml:main',

--- a/tests/print_message_test.py
+++ b/tests/print_message_test.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from pre_commit_hooks.print_message import default_message
+from pre_commit_hooks.print_message import main
+
+
+def test_passes_by_default():
+    assert main() == 0
+
+
+def test_fails_with_fail_flag():
+    assert main(['-f']) > 0
+    assert main(['--f']) > 0
+
+
+def test_default_message(capsys):
+    main()
+    stdout, _ = capsys.readouterr()
+    assert stdout.strip() == default_message
+
+
+def test_message_argument(capsys):
+    message = 'a message'
+    main(['-m', message])
+    stdout, _ = capsys.readouterr()
+    assert stdout.strip() == message


### PR DESCRIPTION
We would like to surfaces messages for when certain files (matching a regex) are modified. This PR adds this pre-commit hook and additionally allows you to fail automatically when certain files are modified.

Do I need to add entries to hooks.yaml and the other configs as well? 