### PR TITLE
Validate code to check if datetime.now() is being used

### DIFF
--- a/pre_commit_hooks/detect_datetime_now.py
+++ b/pre_commit_hooks/detect_datetime_now.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import os
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Check if datetime.now is being used.')
+    parser.add_argument('filenames', nargs='*', help='Filenames to check')
+    args = parser.parse_args(argv)
+
+    for filename in args.filenames:
+        if os.path.isfile(filename):
+            with open(filename, 'rb') as f:
+                if b'datetime.now()' in f.read():
+                    return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/tests/detect_datetime_now_test.py
+++ b/tests/detect_datetime_now_test.py
@@ -1,0 +1,17 @@
+import pytest
+
+from pre_commit_hooks.detect_datetime_now import main
+
+TESTS = (
+    ('from datetime import datetime\ncurrent_date = datetime.now()', 1),
+    ('from datetime import datetime', 0),
+)
+
+
+@pytest.mark.parametrize(('input_s', 'expected_return_value'), TESTS)
+def test_datetime_now_usage(input_s, expected_return_value, tmpdir):
+    """Test behavior with no datetime.now being used on code."""
+    path = tmpdir.join('test_script.py')
+    path.write(input_s)
+    using_datetime = main([path.strpath])
+    assert using_datetime == expected_return_value


### PR DESCRIPTION
Most of projects that I work on are using UTC datetime, so datetime.now() may cause problems.
This hook can help to avoid such cases.