### PR TITLE
Don't pass filenames for no-commit-to-branch

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -228,6 +228,7 @@
     name: "Don't commit to branch"
     entry: no-commit-to-branch
     language: python
+    pass_filenames: false
     always_run: true
     # for backward compatibility
     files: ''


### PR DESCRIPTION
Resolves #268

```console
$ pre-commit try-repo ~/workspace/pre-commit-hooks/ no-commit-to-branch
===============================================================================
Using config:
===============================================================================
repos:
-   repo: /home/asottile/workspace/pre-commit-hooks/
    sha: 66eb9d3aec1237b5aae3785b22da6b2f699b5d54
    hooks:
    -   id: no-commit-to-branch
===============================================================================
[INFO] Initializing environment for /home/asottile/workspace/pre-commit-hooks/.
[INFO] Installing environment for /home/asottile/workspace/pre-commit-hooks/.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Don't commit to branch...................................................Failed
```

See [`pass_filenames`](https://pre-commit.com/#new-hooks).