### PR TITLE
Ensure tox gets proper language settings.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ setenv =
     GIT_COMMITTER_NAME = "test"
     GIT_AUTHOR_EMAIL = "test@example.com"
     GIT_COMMITTER_EMAIL = "test@example.com"
+	LC_ALL=en_US.UTF-8
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}


### PR DESCRIPTION
If LC_ALL is not passed then the interpreter will assume it is C
(which causes the interpreter to use ASCII). This, in turn, causes
the unicode in various places to trigger a UnicodeDecodeError
exception.

CI workers have that locale set by default.
Some people do not have that locale setting set properly.