### PR TITLE
Explicitly check for `ast.Name`

### DIFF
--- a/pre_commit_hooks/check_builtin_literals.py
+++ b/pre_commit_hooks/check_builtin_literals.py
@@ -30,7 +30,7 @@ class BuiltinTypeVisitor(ast.NodeVisitor):
         return self.allow_dict_kwargs and (getattr(node, 'kwargs', None) or getattr(node, 'keywords', None))
 
     def visit_Call(self, node):
-        if isinstance(node.func, ast.Attribute):
+        if not isinstance(node.func, ast.Name):
             # Ignore functions that are object attributes (`foo.bar()`).
             # Assume that if the user calls `builtins.list()`, they know what
             # they're doing.

--- a/tests/check_builtin_literals_test.py
+++ b/tests/check_builtin_literals_test.py
@@ -16,6 +16,8 @@ def visitor():
 @pytest.mark.parametrize(
     ('expression', 'calls'),
     [
+        # see #285
+        ('x[0]()', []),
         # complex
         ("0j", []),
         ("complex()", [BuiltinTypeCall('complex', 1, 0)]),


### PR DESCRIPTION
Resolves #285