### PR TITLE
Exclude folders from file list

### DIFF
--- a/pre_commit_hooks/detect_private_key.py
+++ b/pre_commit_hooks/detect_private_key.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import argparse
+import os
 import sys
 
 BLACKLIST = [
@@ -22,10 +23,11 @@ def detect_private_key(argv=None):
     private_key_files = []
 
     for filename in args.filenames:
-        with open(filename, 'rb') as f:
-            content = f.read()
-            if any(line in content for line in BLACKLIST):
-                private_key_files.append(filename)
+        if os.path.isfile(filename):
+            with open(filename, 'rb') as f:
+                content = f.read()
+                if any(line in content for line in BLACKLIST):
+                    private_key_files.append(filename)
 
     if private_key_files:
         for private_key_file in private_key_files:


### PR DESCRIPTION
**Issue**

If a project contains a git submodule, this submodule may be mistakenly listed as a file, and an `open` operation will then be called on it, resulting in a runtime error.

**Resolution**

This PR addresses that issue by performing an explicit check to exclude folders from the check intended to be performed on files.