### PR TITLE
Remove autopep8-wrapper in favor of autopep8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
-    -   id: autopep8-wrapper
     -   id: check-docstring-first
     -   id: check-json
     -   id: check-added-large-files
@@ -13,6 +12,10 @@ repos:
     -   id: name-tests-test
     -   id: requirements-txt-fixer
     -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4
+    hooks:
+    -   id: autopep8
 -   repo: https://github.com/pre-commit/pre-commit
     rev: v1.7.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ Add this to your `.pre-commit-config.yaml`
 
 ### Hooks available
 
-- `autopep8-wrapper` - Runs autopep8 over python source.
-    - Ignore PEP 8 violation types with `args: ['-i', '--ignore=E000,...']` or
-      through configuration of the `[pycodestyle]` section in
-      setup.cfg / tox.ini.
 - `check-added-large-files` - Prevent giant files from being committed.
     - Specify what is "too large" with `args: ['--maxkb=123']` (default=500kB).
     - If `git-lfs` is installed, lfs files will be skipped
@@ -86,7 +82,6 @@ Add this to your `.pre-commit-config.yaml`
       `master` is the default if no argument is set.
     - `-b` / `--branch` may be specified multiple times to protect multiple
       branches.
-- `pyflakes` - Run pyflakes on your python files.
 - `pretty-format-json` - Checks that all your JSON files are pretty.  "Pretty"
   here means that keys are sorted and indented.  You can configure this with
   the following commandline options:
@@ -101,6 +96,12 @@ Add this to your `.pre-commit-config.yaml`
       use `args: ['--markdown-linebreak-ext=txt,text']` to add other extensions,
       `args: ['--markdown-linebreak-ext=*']` to preserve them for all files,
       or `args: ['--no-markdown-linebreak-ext']` to disable and always trim.
+
+### Deprecated / replaced hooks
+
+- `autopep8-wrapper`: instead use
+  [mirrors-autopep8](https://github.com/pre-commit/mirrors-autopep8)
+- `pyflakes`: instead use `flake8`
 
 ### As a standalone package
 

--- a/pre_commit_hooks/autopep8_wrapper.py
+++ b/pre_commit_hooks/autopep8_wrapper.py
@@ -2,28 +2,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import io
-import sys
-
-import autopep8
-
 
 def main(argv=None):
-    argv = argv if argv is not None else sys.argv[1:]
-    args = autopep8.parse_args(argv, apply_config=True)
-
-    retv = 0
-    for filename in args.files:
-        with io.open(filename, encoding='UTF-8') as f:
-            original_contents = f.read()
-        new_contents = autopep8.fix_code(original_contents, args)
-        if original_contents != new_contents:
-            print('Fixing {}'.format(filename))
-            retv = 1
-            with io.open(filename, 'w', encoding='UTF-8') as output_file:
-                output_file.write(new_contents)
-
-    return retv
+    raise SystemExit(
+        'autopep8-wrapper is deprecated.  Instead use autopep8 directly via '
+        'https://github.com/pre-commit/mirrors-autopep8',
+    )
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,7 @@ setup(
 
     packages=find_packages(exclude=('tests*', 'testing*')),
     install_requires=[
-        # quickfix to prevent pycodestyle conflicts
-        'flake8!=2.5.3',
-        'autopep8>=1.3',
+        'flake8',
         'pyyaml',
         'six',
     ],

--- a/tests/autopep8_wrapper_test.py
+++ b/tests/autopep8_wrapper_test.py
@@ -6,23 +6,8 @@ import pytest
 from pre_commit_hooks.autopep8_wrapper import main
 
 
-@pytest.mark.parametrize(
-    ('input_src', 'expected_ret', 'output_src'),
-    (
-        ('print(1    + 2)\n', 1, 'print(1 + 2)\n'),
-        ('print(1 + 2)\n', 0, 'print(1 + 2)\n'),
-    ),
-)
-def test_main_failing(tmpdir, input_src, expected_ret, output_src):
-    path = tmpdir.join('test.py')
-    path.write(input_src)
-    ret = main([path.strpath, '-i', '-v'])
-    assert ret == expected_ret
-    assert path.read() == output_src
-
-
-def test_respects_config_file(tmpdir):
-    with tmpdir.as_cwd():
-        tmpdir.join('setup.cfg').write('[pycodestyle]\nignore=E221')
-        tmpdir.join('test.py').write('print(1    + 2)\n')
-        assert main(['test.py', '-i', '-v']) == 0
+def test_invariantly_fails():
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    msg, = excinfo.value.args
+    assert 'https://github.com/pre-commit/mirrors-autopep8' in msg


### PR DESCRIPTION
Resolves #92 

this is a breaking change, would be released as 2.x

fortunately this won't break people until they upgrade their hook versions.  and even then it gives a helpful message so probably not the worst break 🤷‍♂️ 

The fix is easy as well, see the diff in `.pre-commit-config.yaml`