### PR TITLE
Fix #326: Handle CRLF in end-of-file-fixer

### DIFF
--- a/pre_commit_hooks/end_of_file_fixer.py
+++ b/pre_commit_hooks/end_of_file_fixer.py
@@ -15,13 +15,13 @@ def fix_file(file_obj):
         return 0
     last_character = file_obj.read(1)
     # last_character will be '' for an empty file
-    if last_character != b'\n' and last_character != b'':
+    if last_character not in {b'\n', b'\r'} and last_character != b'':
         # Needs this seek for windows, otherwise IOError
         file_obj.seek(0, os.SEEK_END)
         file_obj.write(b'\n')
         return 1
 
-    while last_character == b'\n' or last_character == b'\r':
+    while last_character in {b'\n', b'\r'}:
         # Deal with the beginning of the file
         if file_obj.tell() == 1:
             # If we've reached the beginning of the file and it is all
@@ -38,8 +38,10 @@ def fix_file(file_obj):
     # newlines.  If we find extraneous newlines, then backtrack and trim them.
     position = file_obj.tell()
     remaining = file_obj.read()
-    for sequence in [b'\n', b'\r\n']:
-        if remaining.startswith(sequence) and len(remaining) > len(sequence):
+    for sequence in (b'\n', b'\r\n', b'\r'):
+        if remaining == sequence:
+            return 0
+        elif remaining.startswith(sequence):
             file_obj.seek(position + len(sequence))
             file_obj.truncate()
             return 1

--- a/pre_commit_hooks/end_of_file_fixer.py
+++ b/pre_commit_hooks/end_of_file_fixer.py
@@ -21,7 +21,7 @@ def fix_file(file_obj):
         file_obj.write(b'\n')
         return 1
 
-    while last_character == b'\n':
+    while last_character == b'\n' or last_character == b'\r':
         # Deal with the beginning of the file
         if file_obj.tell() == 1:
             # If we've reached the beginning of the file and it is all
@@ -39,8 +39,9 @@ def fix_file(file_obj):
     # there are extraneous newlines at the ned of the file.  Then backtrack and
     # trim the end off.
     if len(file_obj.read(2)) == 2:
-        file_obj.seek(-1, os.SEEK_CUR)
+        file_obj.seek(-2, os.SEEK_CUR)
         file_obj.truncate()
+        file_obj.write(b'\n')
         return 1
 
     return 0

--- a/pre_commit_hooks/end_of_file_fixer.py
+++ b/pre_commit_hooks/end_of_file_fixer.py
@@ -35,14 +35,14 @@ def fix_file(file_obj):
         last_character = file_obj.read(1)
 
     # Our current position is at the end of the file just before any amount of
-    # newlines.  If we read two characters and get two newlines back we know
-    # there are extraneous newlines at the ned of the file.  Then backtrack and
-    # trim the end off.
-    if len(file_obj.read(2)) == 2:
-        file_obj.seek(-2, os.SEEK_CUR)
-        file_obj.truncate()
-        file_obj.write(b'\n')
-        return 1
+    # newlines.  If we find extraneous newlines, then backtrack and trim them.
+    position = file_obj.tell()
+    remaining = file_obj.read()
+    for sequence in [b'\n', b'\r\n']:
+        if remaining.startswith(sequence) and len(remaining) > len(sequence):
+            file_obj.seek(position + len(sequence))
+            file_obj.truncate()
+            return 1
 
     return 0
 

--- a/tests/end_of_file_fixer_test.py
+++ b/tests/end_of_file_fixer_test.py
@@ -15,6 +15,8 @@ TESTS = (
     (b'foo', 1, b'foo\n'),
     (b'foo\n\n\n', 1, b'foo\n'),
     (b'\xe2\x98\x83', 1, b'\xe2\x98\x83\n'),
+    (b'foo\r\n', 1, b'foo\n'),
+    (b'foo\r\n\r\n', 1, b'foo\n'),
 )
 
 

--- a/tests/end_of_file_fixer_test.py
+++ b/tests/end_of_file_fixer_test.py
@@ -15,8 +15,8 @@ TESTS = (
     (b'foo', 1, b'foo\n'),
     (b'foo\n\n\n', 1, b'foo\n'),
     (b'\xe2\x98\x83', 1, b'\xe2\x98\x83\n'),
-    (b'foo\r\n', 1, b'foo\n'),
-    (b'foo\r\n\r\n', 1, b'foo\n'),
+    (b'foo\r\n', 0, b'foo\r\n'),
+    (b'foo\r\n\r\n\r\n', 1, b'foo\r\n'),
 )
 
 

--- a/tests/end_of_file_fixer_test.py
+++ b/tests/end_of_file_fixer_test.py
@@ -17,6 +17,8 @@ TESTS = (
     (b'\xe2\x98\x83', 1, b'\xe2\x98\x83\n'),
     (b'foo\r\n', 0, b'foo\r\n'),
     (b'foo\r\n\r\n\r\n', 1, b'foo\r\n'),
+    (b'foo\r', 0, b'foo\r'),
+    (b'foo\r\r\r\r', 1, b'foo\r'),
 )
 
 


### PR DESCRIPTION
I'm not sure if it's a problem that this approach always replaces a final `\r\n` with `\n`, if that could conflict with the mixed-line-ending hook or Git settings. On one hand, the existing implementation always wrote `\n` if there was no final line break, so this is consistent with that, but then another hook could convert that `\n` to `\r\n`, and this hook would have just ignored it.