### PR TITLE
Fix/aws credentials docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add this to your `.pre-commit-config.yaml`
 - `detect-aws-credentials` - Checks for the existence of AWS secrets that you
   have set up with the AWS CLI.
   The following arguments are available:
-  - `--credentials-file CREDENTIAL_FILES` - additional AWS CLI style
+  - `--credentials-file CREDENTIALS_FILE` - additional AWS CLI style
     configuration file in a non-standard location to fetch configured
     credentials from. Can be repeated multiple times.
   - `--allow-missing-credentials` - Allow hook to pass when no credentials are

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Add this to your `.pre-commit-config.yaml`
   - `--credentials-file` - additional AWS CLI style configuration file in a
     non-standard location to fetch configured credentials from. Can be repeated
     multiple times.
+  - `--allow-missing-credentials` - Allow hook to pass when no credentials are
+    detected.
 - `detect-private-key` - Checks for the existence of private keys.
 - `double-quote-string-fixer` - This hook replaces double quoted strings
   with single quoted strings.

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Add this to your `.pre-commit-config.yaml`
 - `detect-aws-credentials` - Checks for the existence of AWS secrets that you
   have set up with the AWS CLI.
   The following arguments are available:
-  - `--credentials-file` - additional AWS CLI style configuration file in a
-    non-standard location to fetch configured credentials from. Can be repeated
-    multiple times.
+  - `--credentials-file CREDENTIAL_FILES` - additional AWS CLI style
+    configuration file in a non-standard location to fetch configured
+    credentials from. Can be repeated multiple times.
   - `--allow-missing-credentials` - Allow hook to pass when no credentials are
     detected.
 - `detect-private-key` - Checks for the existence of private keys.

--- a/pre_commit_hooks/detect_aws_credentials.py
+++ b/pre_commit_hooks/detect_aws_credentials.py
@@ -87,7 +87,7 @@ def main(argv=None):
     parser.add_argument('filenames', nargs='+', help='Filenames to run')
     parser.add_argument(
         '--credentials-file',
-        dest='credential_files',
+        dest='credentials_file',
         action='append',
         default=[
             '~/.aws/config', '~/.aws/credentials', '/etc/boto.cfg', '~/.boto',
@@ -105,7 +105,7 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
-    credential_files = set(args.credential_files)
+    credential_files = set(args.credentials_file)
 
     # Add the credentials files configured via environment variables to the set
     # of files to to gather AWS secrets from.

--- a/pre_commit_hooks/detect_aws_credentials.py
+++ b/pre_commit_hooks/detect_aws_credentials.py
@@ -93,8 +93,8 @@ def main(argv=None):
             '~/.aws/config', '~/.aws/credentials', '/etc/boto.cfg', '~/.boto',
         ],
         help=(
-            'Location of additional AWS credential files from which to get '
-            'secret keys from'
+            'Location of additional AWS credential file from which to get '
+            'secret keys. Can be passed multiple times.'
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
* Documents the previously undocumented `--allow-missing-credentials` switch to `detect-aws-credentials`. 
* Documents the required argument to `--credentials-file`

By the way, `--credentials-file` seems to be a misnomer: it takes _n_ files and even the destination var is named `credential_files`. Maybe adding `--credential-files` and undocumenting `--credentials-file` (for backward compatibility) would make sense. If you agree I can send a separate PR.