### PR TITLE
fix(metadata): remove `autopep8-wrapper`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,3 @@
--   id: autopep8-wrapper
-    name: autopep8 wrapper
-    description: "Runs autopep8 over python source.  If you configure additional arguments you'll want to at least include -i."
-    entry: autopep8-wrapper
-    language: python
-    types: [python]
-    args: [-i]
 -   id: check-added-large-files
     name: Check for added large files
     description: Prevent giant files from being committed


### PR DESCRIPTION
`autopep8-wrapper` was moved to `pre-commit/mirrors-autopep8` as of release v2.0.0.