### PR TITLE
Turn off pre-commit's automated multiprocessing for flake8

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -136,6 +136,7 @@
     entry: flake8
     language: python
     types: [python]
+    require_serial: true
 -   id: forbid-new-submodules
     name: Forbid new submodules
     language: python


### PR DESCRIPTION
flake8 internally implements multiprocessing, disabling pre-commit's improves performance