### PR TITLE
Run check-byte-order-marker against all text types

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -21,7 +21,7 @@
     description: Forbid files which have a UTF-8 byte-order marker
     entry: check-byte-order-marker
     language: python
-    types: [python]
+    types: [text]
 -   id: check-builtin-literals
     name: Check builtin type constructor use
     description: Require literal syntax when initializing empty or zero Python builtin types.


### PR DESCRIPTION
Run check-byte-order-marker against all text types, not just Python files, as discussed in #371 . (Let me know if this PR is too minimal.)

Resolves #371 