### PR TITLE
Add check-toml hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -70,6 +70,12 @@
     entry: check-symlinks
     language: python
     types: [symlink]
+-   id: check-toml
+    name: Check Toml
+    description: This hook checks toml files for parseable syntax.
+    entry: check-toml
+    language: python
+    types: [toml]
 -   id: check-vcs-permalinks
     name: Check vcs permalinks
     description: Ensures that links to vcs websites are permalinks.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Add this to your `.pre-commit-config.yaml`
 - `check-json` - Attempts to load all json files to verify syntax.
 - `check-merge-conflict` - Check for files that contain merge conflict strings.
 - `check-symlinks` - Checks for symlinks which do not point to anything.
+- `check-toml` - Attempts to load all TOML files to verify syntax.
 - `check-vcs-permalinks` - Ensures that links to vcs websites are permalinks.
 - `check-xml` - Attempts to load all xml files to verify syntax.
 - `check-yaml` - Attempts to load all yaml files to verify syntax.

--- a/pre_commit_hooks/check_toml.py
+++ b/pre_commit_hooks/check_toml.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+
+import argparse
+import sys
+from typing import Optional
+from typing import Sequence
+
+import pytoml
+
+
+def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
+    parser = argparse.ArgumentParser()
+    parser.add_argument('filenames', nargs='*', help='Filenames to check.')
+    args = parser.parse_args(argv)
+
+    retval = 0
+    for filename in args.filenames:
+        try:
+            with open(filename) as f:
+                pytoml.load(f)
+        except pytoml.TomlError as exc:
+            print(exc)
+            retval = 1
+    return retval
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pre_commit_hooks/check_toml.py
+++ b/pre_commit_hooks/check_toml.py
@@ -5,7 +5,7 @@ import sys
 from typing import Optional
 from typing import Sequence
 
-import pytoml
+import toml
 
 
 def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
@@ -17,8 +17,8 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
     for filename in args.filenames:
         try:
             with open(filename) as f:
-                pytoml.load(f)
-        except pytoml.TomlError as exc:
+                toml.load(f)
+        except toml.TomlDecodeError as exc:
             print(exc)
             retval = 1
     return retval

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ packages = find:
 install_requires =
     flake8
     ruamel.yaml>=0.15
+    pytoml
     six
     typing; python_version<"3.5"
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
@@ -43,6 +44,7 @@ console_scripts =
     check-json = pre_commit_hooks.check_json:main
     check-merge-conflict = pre_commit_hooks.check_merge_conflict:main
     check-symlinks = pre_commit_hooks.check_symlinks:main
+    check-toml = pre_commit_hooks.check_toml:main
     check-vcs-permalinks = pre_commit_hooks.check_vcs_permalinks:main
     check-xml = pre_commit_hooks.check_xml:main
     check-yaml = pre_commit_hooks.check_yaml:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires =
     flake8
     ruamel.yaml>=0.15
-    pytoml
+    toml
     six
     typing; python_version<"3.5"
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*


### PR DESCRIPTION
It is important to have such hook
to avoid committing non-valid `pyproject.toml` or `Pipfile`.

Related to #309.