### PR TITLE
Add regex matching to no-commit-to-branch hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Add this to your `.pre-commit-config.yaml`
     - `-b` / `--branch` may be specified multiple times to protect multiple
       branches.
     - `-p` / `--pattern` can be used to protect branches that match a supplied regex
-     (e.g. `--pattern, release/.*`). May be specified multiple times.
+      (e.g. `--pattern, release/.*`). May be specified multiple times.
 - `pretty-format-json` - Checks that all your JSON files are pretty.  "Pretty"
   here means that keys are sorted and indented.  You can configure this with
   the following commandline options:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Add this to your `.pre-commit-config.yaml`
 - `name-tests-test` - Assert that files in tests/ end in `_test.py`.
     - Use `args: ['--django']` to match `test*.py` instead.
 - `no-commit-to-branch` - Protect specific branches from direct checkins.
-    - Use `args: [--branch, staging, --branch, master]` to set the branch.
+    - Use `args: [--branch, staging, --branch, master, --branch, release/*]` to set the branch.
       `master` is the default if no argument is set.
     - `-b` / `--branch` may be specified multiple times to protect multiple
       branches.

--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ Add this to your `.pre-commit-config.yaml`
 - `name-tests-test` - Assert that files in tests/ end in `_test.py`.
     - Use `args: ['--django']` to match `test*.py` instead.
 - `no-commit-to-branch` - Protect specific branches from direct checkins.
-    - Use `args: [--branch, staging, --branch, master, --branch, release/*]` to set the branch.
+    - Use `args: [--branch, staging, --branch, master]` to set the branch.
       `master` is the default if no argument is set.
     - `-b` / `--branch` may be specified multiple times to protect multiple
       branches.
+    - `-p` / `--pattern` can be used to protect branches that match a supplied regex
+     (e.g. `--pattern, release/.*`). May be specified multiple times.
 - `pretty-format-json` - Checks that all your JSON files are pretty.  "Pretty"
   here means that keys are sorted and indented.  You can configure this with
   the following commandline options:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Add this to your `.pre-commit-config.yaml`
     - Use `args: ['--django']` to match `test*.py` instead.
 - `no-commit-to-branch` - Protect specific branches from direct checkins.
     - Use `args: [--branch, staging, --branch, master]` to set the branch.
-      `master` is the default if no argument is set.
+      `master` is the default if no branch argument is set.
     - `-b` / `--branch` may be specified multiple times to protect multiple
       branches.
     - `-p` / `--pattern` can be used to protect branches that match a supplied regex

--- a/pre_commit_hooks/no_commit_to_branch.py
+++ b/pre_commit_hooks/no_commit_to_branch.py
@@ -2,16 +2,16 @@ from __future__ import print_function
 
 import argparse
 import re
+from typing import FrozenSet
 from typing import Optional
 from typing import Sequence
-from typing import Set
 
 from pre_commit_hooks.util import CalledProcessError
 from pre_commit_hooks.util import cmd_output
 
 
-def is_on_branch(protected, patterns=set()):
-    # type: (Set[str], Set[str]) -> bool
+def is_on_branch(protected, patterns=frozenset()):
+    # type: (FrozenSet[str], FrozenSet[str]) -> bool
     try:
         ref_name = cmd_output('git', 'symbolic-ref', 'HEAD')
     except CalledProcessError:
@@ -33,13 +33,13 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
         '-p', '--pattern', action='append',
         help=(
             'regex pattern for branch name to disallow commits to, '
-            'May be specified multiple times'
+            'may be specified multiple times'
         ),
     )
     args = parser.parse_args(argv)
 
-    protected = set(args.branch or ('master',))
-    patterns = set(args.pattern or ())
+    protected = frozenset(args.branch or ('master',))
+    patterns = frozenset(args.pattern or ())
     return int(is_on_branch(protected, patterns))
 
 

--- a/pre_commit_hooks/no_commit_to_branch.py
+++ b/pre_commit_hooks/no_commit_to_branch.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import argparse
 import re
-from typing import FrozenSet
+from typing import AbstractSet
 from typing import Optional
 from typing import Sequence
 
@@ -11,7 +11,7 @@ from pre_commit_hooks.util import cmd_output
 
 
 def is_on_branch(protected, patterns=frozenset()):
-    # type: (FrozenSet[str], FrozenSet[str]) -> bool
+    # type: (AbstractSet[str], AbstractSet[str]) -> bool
     try:
         ref_name = cmd_output('git', 'symbolic-ref', 'HEAD')
     except CalledProcessError:

--- a/pre_commit_hooks/no_commit_to_branch.py
+++ b/pre_commit_hooks/no_commit_to_branch.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import argparse
+import fnmatch
 from typing import Optional
 from typing import Sequence
 from typing import Set
@@ -11,11 +12,12 @@ from pre_commit_hooks.util import cmd_output
 
 def is_on_branch(protected):  # type: (Set[str]) -> bool
     try:
-        branch = cmd_output('git', 'symbolic-ref', 'HEAD')
+        ref_name = cmd_output('git', 'symbolic-ref', 'HEAD')
     except CalledProcessError:
         return False
-    chunks = branch.strip().split('/')
-    return '/'.join(chunks[2:]) in protected
+    chunks = ref_name.strip().split('/')
+    branch_name = '/'.join(chunks[2:])
+    return any(fnmatch.fnmatch(branch_name, s) for s in protected)
 
 
 def main(argv=None):  # type: (Optional[Sequence[str]]) -> int

--- a/pre_commit_hooks/no_commit_to_branch.py
+++ b/pre_commit_hooks/no_commit_to_branch.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import argparse
-import fnmatch
+import re
 from typing import Optional
 from typing import Sequence
 from typing import Set
@@ -10,14 +10,17 @@ from pre_commit_hooks.util import CalledProcessError
 from pre_commit_hooks.util import cmd_output
 
 
-def is_on_branch(protected):  # type: (Set[str]) -> bool
+def is_on_branch(protected, patterns=set()):
+    # type: (Set[str], Set[str]) -> bool
     try:
         ref_name = cmd_output('git', 'symbolic-ref', 'HEAD')
     except CalledProcessError:
         return False
     chunks = ref_name.strip().split('/')
     branch_name = '/'.join(chunks[2:])
-    return any(fnmatch.fnmatch(branch_name, s) for s in protected)
+    return branch_name in protected or any(
+        re.match(p, branch_name) for p in patterns
+    )
 
 
 def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
@@ -26,10 +29,18 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
         '-b', '--branch', action='append',
         help='branch to disallow commits to, may be specified multiple times',
     )
+    parser.add_argument(
+        '-p', '--pattern', action='append',
+        help=(
+            'regex pattern for branch name to disallow commits to, '
+            'May be specified multiple times'
+        ),
+    )
     args = parser.parse_args(argv)
 
     protected = set(args.branch or ('master',))
-    return int(is_on_branch(protected))
+    patterns = set(args.pattern or ())
+    return int(is_on_branch(protected, patterns))
 
 
 if __name__ == '__main__':

--- a/tests/no_commit_to_branch_test.py
+++ b/tests/no_commit_to_branch_test.py
@@ -44,6 +44,19 @@ def test_forbid_multiple_branches(temp_git_dir, branch_name):
         assert main(('--branch', 'b1', '--branch', 'b2'))
 
 
+def test_branch_wildcard_fail(temp_git_dir):
+    with temp_git_dir.as_cwd():
+        cmd_output('git', 'checkout', '-b', 'another/branch')
+        assert is_on_branch({'another/*'}) is True
+
+
+@pytest.mark.parametrize('branch_name', ('master', 'another/branch'))
+def test_branch_wildcard_multiple_branches_fail(temp_git_dir, branch_name):
+    with temp_git_dir.as_cwd():
+        cmd_output('git', 'checkout', '-b', branch_name)
+        assert main(('--branch', 'master', '--branch', 'another/*'))
+
+
 def test_main_default_call(temp_git_dir):
     with temp_git_dir.as_cwd():
         cmd_output('git', 'checkout', '-b', 'anotherbranch')

--- a/tests/no_commit_to_branch_test.py
+++ b/tests/no_commit_to_branch_test.py
@@ -44,17 +44,17 @@ def test_forbid_multiple_branches(temp_git_dir, branch_name):
         assert main(('--branch', 'b1', '--branch', 'b2'))
 
 
-def test_branch_wildcard_fail(temp_git_dir):
+def test_branch_pattern_fail(temp_git_dir):
     with temp_git_dir.as_cwd():
         cmd_output('git', 'checkout', '-b', 'another/branch')
-        assert is_on_branch({'another/*'}) is True
+        assert is_on_branch(set(), {'another/.*'}) is True
 
 
 @pytest.mark.parametrize('branch_name', ('master', 'another/branch'))
-def test_branch_wildcard_multiple_branches_fail(temp_git_dir, branch_name):
+def test_branch_pattern_multiple_branches_fail(temp_git_dir, branch_name):
     with temp_git_dir.as_cwd():
         cmd_output('git', 'checkout', '-b', branch_name)
-        assert main(('--branch', 'master', '--branch', 'another/*'))
+        assert main(('--branch', 'master', '--pattern', 'another/.*'))
 
 
 def test_main_default_call(temp_git_dir):


### PR DESCRIPTION
Add wildcard matching to no-commit-to-branch hook, so that commits can be blocked on, for example, all release branches with 'release/*'

Addresses: #375