### PR TITLE
Add sys.exit(main()) to file_contents_sorter.py

### DIFF
--- a/pre_commit_hooks/file_contents_sorter.py
+++ b/pre_commit_hooks/file_contents_sorter.py
@@ -12,6 +12,7 @@ conflicts and keep the file nicely ordered.
 from __future__ import print_function
 
 import argparse
+import sys
 from typing import IO
 from typing import Optional
 from typing import Sequence
@@ -53,3 +54,7 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
             retv |= ret_for_file
 
     return retv
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
I was trying to use `file_contents_sorter` hook.

I noticed that it is missing standalone invocation capability. Now I can use it as a standalone script to sort my files.

I was still not sure how to use it though inside .pre-commit-config.yaml. I've added

```
- id: file-contents-sorter
  args: [path/to/my-file.txt]
```

to my .pre-commit-config.yaml but it keeps saying

```
File Contents Sorter.................................(no files to check)Skipped
```

Although I staged that file for commit, and changed it in a way it should trigger.

Then I realized that I also need `always_run: true`:

```
- id: file-contents-sorter
  args: [path/to/my-file.txt]
  always_run: true
```

This was surprising and I was able to find out only by reading the code. Maybe it could be pointed out prominently  in the README if you think it's helpful.