### PR TITLE
Add dates to changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-2.3.0
-=====
+2.3.0 - 2019-08-05
+==================
 
 ### Features
 - Add `rpdb` to detected debuggers in `debug-statements`
@@ -17,31 +17,31 @@
 - Fix `git-lfs` tests in azure pipelines
     - #403 PR by @ssbarnea.
 
-2.2.3
-=====
+2.2.3 - 2019-05-16
+==================
 
 ### Fixes
 - Handle CRLF line endings in `double-quote-string-fixer`
     - #385 issue by @Trim21.
     - #386 PR by @asottile.
 
-2.2.2
-=====
+2.2.2 - 2019-05-15
+==================
 
 ### Fixes
 - Handle CRLF line endings in `fix-encoding-pragma`
     - #384 PR by @asottile.
 
-2.2.1
-=====
+2.2.1 - 2019-04-21
+==================
 
 ### Fixes
 - Use UTF-8 to load yaml files
     - #377 issue by @roottool.
     - #378 PR by @roottool.
 
-2.2.0
-=====
+2.2.0 - 2019-04-20
+==================
 
 ### Features
 - Switch from `pyyaml` to `ruamel.yaml`
@@ -71,8 +71,8 @@
 - `pre-commit-hooks` now is type checked with mypy.
     - #360 PR by @asottile.
 
-2.1.0
-=====
+2.1.0 - 2018-12-26
+==================
 
 ### Features
 - Detect PGP/GPG private keys in `detect-private-key`
@@ -93,8 +93,8 @@
     - #343 PR by @TheKevJames.
 
 
-2.0.0
-=====
+2.0.0 - 2018-10-12
+==================
 
 ### Breaking changes
 
@@ -125,8 +125,8 @@
 
 [mirrors-autopep8]: https://github.com/pre-commit/mirrors-autopep8
 
-1.4.0-1
-=======
+1.4.0-1 - 2018-09-27
+====================
 
 (Note: this is a tag-only release as no code changes occurred)
 
@@ -135,8 +135,8 @@
     - #315 issue by @revolter.
     - #317 PR by @revolter.
 
-1.4.0
-=====
+1.4.0 - 2018-07-22
+==================
 
 ### Features
 - `no-commit-to-branch`: allow `--branch` to be specified multiple times
@@ -159,8 +159,8 @@
 - Test against python3.7
     - #304 PR by @expobrain.
 
-1.3.0
-=====
+1.3.0 - 2018-05-28
+==================
 
 ### Features
 - Add an `--unsafe` argument to `check-yaml` to allow custom yaml tags
@@ -181,23 +181,23 @@
     - #285 issue by @EgoWumpus.
     - #286 PR by @asottile.
 
-1.2.3
-=====
+1.2.3 - 2018-02-28
+==================
 
 ### Fixes
 - `trailing-whitespace` entrypoint was incorrect.
     - f6780b9 by @asottile.
 
-1.2.2
-=====
+1.2.2 - 2018-02-28
+==================
 
 ### Fixes
 - `trailing-whitespace` no longer adds a missing newline at end-of-file
     - #270 issue by @fractos.
     - #271 PR by @asottile.
 
-1.2.1-1
-=======
+1.2.1-1 - 2018-02-24
+====================
 
 (Note: this is a tag-only release as no code changes occurred)
 
@@ -206,8 +206,8 @@
     - #268 issue by @dongyuzheng.
     - #269 PR by @asottile.
 
-1.2.1
-=====
+1.2.1 - 2018-02-19
+==================
 ### Fixes:
 - `detect-aws-credentials` false positive when key was empty
     - #258 issue by @PVSec.
@@ -216,8 +216,8 @@
     - #265 issue by @hectorv.
     - #266 PR by @asottile.
 
-1.2.0
-=====
+1.2.0 - 2018-01-13
+==================
 ### Features:
 - Add new `check-builtin-literals` hook.
     - #249 #251 PR by @benwebber.
@@ -227,14 +227,14 @@
     - #255 issue by @SaMnCo @nicain.
     - #256 PR by @nicain.
 
-1.1.1
-=====
+1.1.1 - 2017-10-19
+==================
 ### Fixes:
 - Fix output interleaving in `check-vcs-permalinks` under python3.
     - #245 PR by @asottile.
 
-1.1.0
-=====
+1.1.0 - 2017-10-12
+==================
 ### Features:
 - `check-yaml` gains a `--allow-multiple-documents` (`-m`) argument to allow
   linting of files using the
@@ -242,8 +242,8 @@
     - pre-commit/pre-commit#635 issue by @geekobi.
     - #244 PR by @asottile.
 
-1.0.0
-=====
+1.0.0 - 2017-10-09
+==================
 ### Features:
 - New hook: `check-vcs-permalinks` for ensuring permalinked github urls.
     - #241 PR by @asottile.
@@ -254,20 +254,20 @@
 - Fix `requirements-txt-fixer` for files ending in comments
     - #243 PR by @asottile.
 
-0.9.5
-=====
+0.9.5 - 2017-09-27
+==================
 - Fix mixed-line-endings `--fix=...` when whole file is a different ending
 
-0.9.4
-=====
+0.9.4 - 2017-09-19
+==================
 - Fix entry point for `mixed-line-ending`
 
-0.9.3
-=====
+0.9.3 - 2017-09-07
+==================
 - New hook: `mixed-line-ending`
 
-0.9.2
-=====
+0.9.2 - 2017-08-21
+==================
 - Report full python version in `check-ast`.
 - Apply a more strict regular expression for `name-tests-test`
 - Upgrade binding for `git-lfs` for `check-added-large-files`.  The oldest
@@ -275,12 +275,12 @@
   files as "lfs" (false negative) and earlier versions will crash.
 - `debug-statements` now works for non-utf-8 files.
 
-0.9.1
-=====
+0.9.1 - 2017-07-02
+==================
 - Add `check-executables-have-shebangs` hook.
 
-0.9.0
-=====
+0.9.0 - 2017-07-02
+==================
 - Add `sort-simple-yaml` hook
 - Fix `requirements-txt-fixer` for empty files
 - Add `file-contents-sorter` hook for sorting flat files
@@ -289,24 +289,24 @@
   allows the text processing hooks to match *all* text files (and to match
   files which would only be classifiable by their shebangs).
 
-0.8.0
-=====
+0.8.0 - 2017-06-06
+==================
 - Add flag allowing missing keys to `detect-aws-credentials`
 - Handle django default `tests.py` in `name-tests-test`
 - Add `--no-ensure-ascii` option to `pretty-format-json`
 - Add `no-commit-to-branch` hook
 
-0.7.1
-=====
+0.7.1 - 2017-02-07
+==================
 - Don't false positive on files where trailing whitespace isn't changed.
 
-0.7.0
-=====
+0.7.0 - 2017-01-21
+==================
 - Improve search for detecting aws keys
 - Add .pre-commit-hooks.yaml for forward compatibility
 
-0.6.1
-=====
+0.6.1 - 2016-11-30
+==================
 - trailing-whitespace-hook: restore original file on catastrophic failure
 - trailing-whitespace-hook: support crlf
 - check-yaml: Use safe_load
@@ -314,20 +314,20 @@
 - check-json: display filename for non-utf8 files
 - New hook: forbid-new-submodules
 
-0.6.0
-=====
+0.6.0 - 2016-08-12
+==================
 - Merge conflict detection no longer crashes on binary files
 - Indentation in json may be an arbitrary separator
 - Editable requirements are properly sorted
 - Encoding pragma fixer pragma is configurable
 
-0.5.1
-=====
+0.5.1 - 2016-05-16
+==================
 - Add a --no-sort-keys to json pretty formatter
 - Add a --remove to fix-encoding-pragma
 
-0.5.0
-=====
+0.5.0 - 2016-04-05
+==================
 - Add check-byte-order-marker
 - Add check-synlinks
 - check-large-files-added understands git-lfs
@@ -340,8 +340,8 @@
 - Allow binary files to pass private key hook
 - Add pretty-format-json hook
 
-0.4.2
-=====
+0.4.2 - 2015-05-31
+==================
 - Add --django to test name checker
 - Add check-merge-conflict hook
 - Remove dependency on plumbum
@@ -350,13 +350,13 @@
 - Teach trailing-whitespace about markdown
 - Quickfix for pyflakes - flake8 version conflict
 
-0.4.1
-=====
+0.4.1 - 2015-03-08
+==================
 - Respect configuration when running autopep8
 - Quickfix for pep8 version conflicts
 
-0.4.0
-=====
+0.4.0 - 2015-02-22
+==================
 - Fix trailing-whitespace on OS X
 - Add check-added-large-files hook
 - Add check-docstring-first hook
@@ -367,18 +367,18 @@
 - Fix end-of-file-fixer for windows
 - Add double-quote-string-fixer hook
 
-0.3.0
-=====
+0.3.0 - 2014-08-22
+==================
 - Add autopep8-wrapper hook
 
-0.2.0
-=====
+0.2.0 - 2014-08-19
+==================
 - Add check-json hook
 
-0.1.1
-=====
+0.1.1 - 2014-06-19
+==================
 - Don't crash on non-parseable files for debug-statement-hook
 
-0.1.0
-=====
+0.1.0 - 2014-06-07
+==================
 - Initial Release


### PR DESCRIPTION
Automated with this script:

```bash
git tag -l | sed 's/^v//g' |
    xargs --replace bash -c 'sed -r -i "s/^({})$/\1 - $(git show --format=%ad --date=short --no-patch v{})/g" CHANGELOG.md'
sed -r -i 's/^(=+)$/\1=============/g' CHANGELOG.md
                     # - 2019-01-01
```