### PR TITLE
Add logic to print diff between expected and actual JSON

### DIFF
--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -115,6 +115,17 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
             if contents != pretty_contents:
                 print('File {} is not pretty-formatted'.format(json_file))
 
+                contents_by_line = ''.join(contents).split('\n')
+                pretty_contents_by_line = ''.join(pretty_contents).split('\n')
+
+                diff = len(contents_by_line) - len(pretty_contents_by_line)
+                if diff > 0:
+                    pretty_contents_by_line.extend([''] * diff)
+
+                for line_num, line in enumerate(contents_by_line):
+                    if line != pretty_contents_by_line[line_num]:
+                        print('{}:{}'.format(json_file, line_num))
+
                 if args.autofix:
                     _autofix(json_file, pretty_contents)
 

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -120,7 +120,10 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
             )
 
             if contents != pretty_contents:
-                print('File {} is not pretty-formatted'.format(json_file))
+                print(
+                    'File {} is not pretty-formatted'.format(json_file),
+                    file=sys.stderr,
+                )
 
                 if args.autofix:
                     _autofix(json_file, pretty_contents)

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -56,12 +56,12 @@ def parse_topkeys(s):  # type: (str) -> List[str]
     return s.split(',')
 
 
-def get_diff(source, target):  # type: (List[str], List[str]) -> str
-    source_lines = ''.join(source).split('\n')
-    target_lines = ''.join(target).split('\n')
-    d = difflib.Differ()
-    diff = d.compare(source_lines, target_lines)
-    return '\n'.join(diff)
+def get_diff(source, target):  # type: (str, str) -> str
+    source_lines = source.splitlines(True)
+    target_lines = target.splitlines(True)
+    diff = ''.join(difflib.ndiff(source_lines, target_lines))
+    print(diff)
+    return diff
 
 
 def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
@@ -105,14 +105,6 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
         default=[],
         help='Ordered list of keys to keep at the top of JSON hashes',
     )
-    parser.add_argument(
-        '--show-expected',
-        action='store_true',
-        dest='show_expected',
-        default=False,
-        help='Show a diff between the input file and expected (pretty) output',
-    )
-
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)
 
@@ -131,11 +123,10 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
             if contents != pretty_contents:
                 print('File {} is not pretty-formatted'.format(json_file))
 
-                if args.show_expected:
-                    print(get_diff(contents, list(pretty_contents)))
-
                 if args.autofix:
                     _autofix(json_file, pretty_contents)
+                else:
+                    print(get_diff(''.join(contents), pretty_contents))
 
                 status = 1
         except ValueError:

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -59,7 +59,7 @@ def parse_topkeys(s):  # type: (str) -> List[str]
 def get_diff(source, target):  # type: (str, str) -> str
     source_lines = source.splitlines(True)
     target_lines = target.splitlines(True)
-    diff = ''.join(difflib.ndiff(source_lines, target_lines))
+    diff = ''.join(difflib.unified_diff(source_lines, target_lines))
     return diff
 
 

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -1,10 +1,10 @@
 from __future__ import print_function
 
 import argparse
+import difflib
 import io
 import json
 import sys
-import difflib
 from collections import OrderedDict
 from typing import List
 from typing import Mapping
@@ -56,7 +56,7 @@ def parse_topkeys(s):  # type: (str) -> List[str]
     return s.split(',')
 
 
-def get_diff(source, target):
+def get_diff(source, target):  # type: (List[str], List[str]) -> str
     source_lines = ''.join(source).split('\n')
     target_lines = ''.join(target).split('\n')
     d = difflib.Differ()
@@ -132,7 +132,7 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
                 print('File {} is not pretty-formatted'.format(json_file))
 
                 if args.show_expected:
-                    print(get_diff(contents, pretty_contents))
+                    print(get_diff(contents, list(pretty_contents)))
 
                 if args.autofix:
                     _autofix(json_file, pretty_contents)

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -60,7 +60,6 @@ def get_diff(source, target):  # type: (str, str) -> str
     source_lines = source.splitlines(True)
     target_lines = target.splitlines(True)
     diff = ''.join(difflib.ndiff(source_lines, target_lines))
-    print(diff)
     return diff
 
 

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -124,6 +124,7 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
                     'File {} is not pretty-formatted'.format(json_file),
                     file=sys.stderr,
                 )
+                sys.stderr.flush()
 
                 if args.autofix:
                     _autofix(json_file, pretty_contents)

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -129,13 +129,7 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
                 if args.autofix:
                     _autofix(json_file, pretty_contents)
                 else:
-                    print(
-                        get_diff(
-                            ''.join(contents),
-                            pretty_contents,
-                            json_file,
-                        ),
-                    )
+                    print(get_diff(contents, pretty_contents, json_file))
 
                 status = 1
         except ValueError:

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -129,7 +129,10 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
                 if args.autofix:
                     _autofix(json_file, pretty_contents)
                 else:
-                    print(get_diff(contents, pretty_contents, json_file))
+                    print(
+                        get_diff(contents, pretty_contents, json_file),
+                        end='',
+                    )
 
                 status = 1
         except ValueError:

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -1,11 +1,11 @@
 from __future__ import print_function
 
 import argparse
-import difflib
 import io
 import json
 import sys
 from collections import OrderedDict
+from difflib import unified_diff
 from typing import List
 from typing import Mapping
 from typing import Optional
@@ -56,11 +56,11 @@ def parse_topkeys(s):  # type: (str) -> List[str]
     return s.split(',')
 
 
-def get_diff(source, target):  # type: (str, str) -> str
+def get_diff(source, target, file):  # type: (str, str, str) -> str
     source_lines = source.splitlines(True)
     target_lines = target.splitlines(True)
-    diff = ''.join(difflib.unified_diff(source_lines, target_lines))
-    return diff
+    diff = unified_diff(source_lines, target_lines, fromfile=file, tofile=file)
+    return ''.join(diff)
 
 
 def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
@@ -129,7 +129,13 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
                 if args.autofix:
                     _autofix(json_file, pretty_contents)
                 else:
-                    print(get_diff(''.join(contents), pretty_contents))
+                    print(
+                        get_diff(
+                            ''.join(contents),
+                            pretty_contents,
+                            json_file,
+                        ),
+                    )
 
                 status = 1
         except ValueError:

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -108,6 +108,7 @@ def test_badfile_main():
 
 
 def test_diffing_output(capsys):
+    resource_path = get_resource_path('not_pretty_formatted_json.json')
     expected_retval = 1
     expected_out = '''  {
 -     "foo":
@@ -125,9 +126,11 @@ def test_diffing_output(capsys):
   }
 
 '''
+    expected_err = 'File {} is not pretty-formatted\n'.format(resource_path)
 
-    actual_retval = main([get_resource_path('not_pretty_formatted_json.json')])
-    out, err = capsys.readouterr()
+    actual_retval = main([resource_path])
+    actual_out, actual_err = capsys.readouterr()
 
     assert actual_retval == expected_retval
-    assert out == expected_out
+    assert actual_out == expected_out
+    assert actual_err == expected_err

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -110,7 +110,8 @@ def test_badfile_main():
 def test_diffing_output(capsys):
     resource_path = get_resource_path('not_pretty_formatted_json.json')
     expected_retval = 1
-    expected_out = '''  {
+    expected_out = '''\
+  {
 -     "foo":
 -     "bar",
 -         "alist": [2, 34, 234],

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 
 import pytest
@@ -110,9 +111,13 @@ def test_badfile_main():
 def test_diffing_output(capsys):
     resource_path = get_resource_path('not_pretty_formatted_json.json')
     expected_retval = 1
+    a = os.path.join('a', resource_path)
+    b = os.path.join('b', resource_path)
     expected_out = '''\
---- \n+++ \n@@ -1,6 +1,9 @@
- {
+--- {}
++++ {}
+@@ -1,6 +1,9 @@
+ {{
 -    "foo":
 -    "bar",
 -        "alist": [2, 34, 234],
@@ -124,9 +129,9 @@ def test_diffing_output(capsys):
 +  ],
 +  "blah": null,
 +  "foo": "bar"
- }
+ }}
 
-'''
+'''.format(a, b)
     expected_err = 'File {} is not pretty-formatted\n'.format(resource_path)
 
     actual_retval = main([resource_path])

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -111,9 +111,7 @@ def test_diffing_output(capsys):
     resource_path = get_resource_path('not_pretty_formatted_json.json')
     expected_retval = 1
     expected_out = '''\
----
-+++
-@@ -1,6 +1,9 @@
+--- \n+++ \n@@ -1,6 +1,9 @@
  {
 -    "foo":
 -    "bar",
@@ -128,7 +126,7 @@ def test_diffing_output(capsys):
 +  "foo": "bar"
  }
 
-'''  # noqa: W291
+'''
     expected_err = 'File {} is not pretty-formatted\n'.format(resource_path)
 
     actual_retval = main([resource_path])

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -126,21 +126,6 @@ def test_diffing_output(capsys):
 +   "foo": "bar"
   }
 
-  {
--     "foo":
--     "bar",
--         "alist": [2, 34, 234],
-+   "alist": [
-+     2,
-+     34,
-+     234
-+   ],
--   "blah": null
-+   "blah": null,
-?               +
-+   "foo": "bar"
-  }
-
 
 '''
     # output should include a line with the filepath, build it here

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -130,7 +130,6 @@ def test_diffing_output(capsys):
 +  "blah": null,
 +  "foo": "bar"
  }}
-
 '''.format(a, b)
     expected_err = 'File {} is not pretty-formatted\n'.format(resource_path)
 

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -108,10 +108,8 @@ def test_badfile_main():
 
 
 def test_diffing_output(capsys):
-    resource_path = get_resource_path('not_pretty_formatted_json.json')
     expected_retval = 1
-    expected_diff = '''
-  {
+    expected_out = '''  {
 -     "foo":
 -     "bar",
 -         "alist": [2, 34, 234],
@@ -126,17 +124,10 @@ def test_diffing_output(capsys):
 +   "foo": "bar"
   }
 
-
 '''
-    # output should include a line with the filepath, build it here
-    file_output_line = 'File {} is not pretty-formatted'.format(resource_path)
-    # prepend the above line to the diff
-    expected_output = file_output_line + expected_diff
 
-    actual_retval = main([resource_path])
-    actual_output = capsys.readouterr()
+    actual_retval = main([get_resource_path('not_pretty_formatted_json.json')])
+    out, err = capsys.readouterr()
 
     assert actual_retval == expected_retval
-
-    actual_output = '\n'.join(actual_output)
-    assert actual_output == expected_output
+    assert out == expected_out

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -111,22 +111,24 @@ def test_diffing_output(capsys):
     resource_path = get_resource_path('not_pretty_formatted_json.json')
     expected_retval = 1
     expected_out = '''\
-  {
--     "foo":
--     "bar",
--         "alist": [2, 34, 234],
-+   "alist": [
-+     2,
-+     34,
-+     234
-+   ],
--   "blah": null
-+   "blah": null,
-?               +
-+   "foo": "bar"
-  }
+---
++++
+@@ -1,6 +1,9 @@
+ {
+-    "foo":
+-    "bar",
+-        "alist": [2, 34, 234],
+-  "blah": null
++  "alist": [
++    2,
++    34,
++    234
++  ],
++  "blah": null,
++  "foo": "bar"
+ }
 
-'''
+'''  # noqa: W291
     expected_err = 'File {} is not pretty-formatted\n'.format(resource_path)
 
     actual_retval = main([resource_path])


### PR DESCRIPTION
This PR makes the pretty JSON check more verbose when it encounters errors, that way developers can see which lines are causing errors in order to debug.

I haven't seen any talk about adding this anywhere, but would love to hear the maintainers' thoughts on this.