### PR TITLE
trailing-whitespace: add option for custom chars to strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Add this to your `.pre-commit-config.yaml`
       use `args: [--markdown-linebreak-ext=md]` (or other extensions used
       by your markdownfiles).  If for some reason you want to treat all files
       as markdown, use `--markdown-linebreak-ext=*`.
+    - By default, this hook trims all whitespace from the ends of lines.
+      To specify a custom set of characters to trim instead, use `args: [--chars,"<chars to trim>"]`.
 
 ### Deprecated / replaced hooks
 

--- a/pre_commit_hooks/trailing_whitespace_fixer.py
+++ b/pre_commit_hooks/trailing_whitespace_fixer.py
@@ -94,7 +94,7 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
         if _fix_file(
             filename,
             md,
-            None if args.chars is None else bytes(args.chars.encode('utf-8')),
+            None if args.chars is None else args.chars.encode('utf-8'),
         ):
             print('Fixing {}'.format(filename))
             return_code = 1

--- a/pre_commit_hooks/trailing_whitespace_fixer.py
+++ b/pre_commit_hooks/trailing_whitespace_fixer.py
@@ -29,13 +29,15 @@ def _process_line(line, is_markdown, chars_to_strip):
     # type: (bytes, bool, Optional[bytes]) -> bytes
     if line[-2:] == b'\r\n':
         eol = b'\r\n'
+        line = line[:-2]
     elif line[-1:] == b'\n':
         eol = b'\n'
+        line = line[:-1]
     else:
         eol = b''
     # preserve trailing two-space for non-blank lines in markdown files
-    if is_markdown and (not line.isspace()) and line.endswith(b'  ' + eol):
-        return line.rstrip(chars_to_strip) + b'  ' + eol
+    if is_markdown and (not line.isspace()) and line.endswith(b'  '):
+        return line[:-2].rstrip(chars_to_strip) + b'  ' + eol
     return line.rstrip(chars_to_strip) + eol
 
 

--- a/pre_commit_hooks/trailing_whitespace_fixer.py
+++ b/pre_commit_hooks/trailing_whitespace_fixer.py
@@ -7,10 +7,15 @@ from typing import Optional
 from typing import Sequence
 
 
-def _fix_file(filename, is_markdown):  # type: (str, bool) -> bool
+def _fix_file(filename, is_markdown, chars_to_strip):
+    # type: (str, bool, Optional[bytes]) -> bool
     with open(filename, mode='rb') as file_processed:
         lines = file_processed.readlines()
-    newlines = [_process_line(line, is_markdown) for line in lines]
+    newlines = [
+        _process_line(line, is_markdown, chars_to_strip)
+        for line
+        in lines
+    ]
     if newlines != lines:
         with open(filename, mode='wb') as file_processed:
             for line in newlines:
@@ -20,7 +25,8 @@ def _fix_file(filename, is_markdown):  # type: (str, bool) -> bool
         return False
 
 
-def _process_line(line, is_markdown):  # type: (bytes, bool) -> bytes
+def _process_line(line, is_markdown, chars_to_strip):
+    # type: (bytes, bool, Optional[bytes]) -> bytes
     if line[-2:] == b'\r\n':
         eol = b'\r\n'
     elif line[-1:] == b'\n':
@@ -29,8 +35,8 @@ def _process_line(line, is_markdown):  # type: (bytes, bool) -> bytes
         eol = b''
     # preserve trailing two-space for non-blank lines in markdown files
     if is_markdown and (not line.isspace()) and line.endswith(b'  ' + eol):
-        return line.rstrip() + b'  ' + eol
-    return line.rstrip() + eol
+        return line.rstrip(chars_to_strip) + b'  ' + eol
+    return line.rstrip(chars_to_strip) + eol
 
 
 def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
@@ -49,6 +55,11 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
             'Markdown extensions (or *) to not strip linebreak spaces.  '
             'default: %(default)s'
         ),
+    )
+    parser.add_argument(
+        '--chars',
+        help='The set of characters to strip from the end of lines.  '
+        'Defaults to all whitespace characters.',
     )
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)
@@ -78,7 +89,11 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
     for filename in args.filenames:
         _, extension = os.path.splitext(filename.lower())
         md = all_markdown or extension in md_exts
-        if _fix_file(filename, md):
+        if _fix_file(
+            filename,
+            md,
+            None if args.chars is None else bytes(args.chars, 'utf-8'),
+        ):
             print('Fixing {}'.format(filename))
             return_code = 1
     return return_code

--- a/pre_commit_hooks/trailing_whitespace_fixer.py
+++ b/pre_commit_hooks/trailing_whitespace_fixer.py
@@ -94,7 +94,7 @@ def main(argv=None):  # type: (Optional[Sequence[str]]) -> int
         if _fix_file(
             filename,
             md,
-            None if args.chars is None else bytes(args.chars, 'utf-8'),
+            None if args.chars is None else bytes(args.chars.encode('utf-8')),
         ):
             print('Fixing {}'.format(filename))
             return_code = 1

--- a/tests/trailing_whitespace_fixer_test.py
+++ b/tests/trailing_whitespace_fixer_test.py
@@ -94,3 +94,11 @@ def test_custom_charset_no_change(tmpdir):
     path.write('\ta \t\n')
     ret = main([path.strpath, '--chars', ' '])
     assert ret == 0
+
+
+def test_markdown_with_custom_charset(tmpdir):
+    path = tmpdir.join('file.md')
+    path.write('\ta \t   \n')
+    ret = main([path.strpath, '--chars', ' ', '--markdown-linebreak-ext', '*'])
+    assert ret == 1
+    assert path.read() == '\ta \t  \n'

--- a/tests/trailing_whitespace_fixer_test.py
+++ b/tests/trailing_whitespace_fixer_test.py
@@ -78,3 +78,19 @@ def test_preserve_non_utf8_file(tmpdir):
     ret = main([path.strpath])
     assert ret == 1
     assert path.size() == (len(non_utf8_bytes_content) - 1)
+
+
+def test_custom_charset_change(tmpdir):
+    # strip spaces only, no tabs
+    path = tmpdir.join('file.txt')
+    path.write('\ta \t \n')
+    ret = main([path.strpath, '--chars', ' '])
+    assert ret == 1
+    assert path.read() == '\ta \t\n'
+
+
+def test_custom_charset_no_change(tmpdir):
+    path = tmpdir.join('file.txt')
+    path.write('\ta \t\n')
+    ret = main([path.strpath, '--chars', ' '])
+    assert ret == 0


### PR DESCRIPTION
This PR adds a new flag to the `trailing-whitespace` hook, `--chars`, which allows you to specify a custom set of characters to pass to `rstrip`.

This flag was motivated by Common Lisp, in which a common convention is to use `\f` to delineate sections of code. `trailing-whitespace` considers these by default whitespace, and so strips out the section delimiters users want to preserve. In repositories where this convention is used, a custom value for `--chars` can be specified. This hook is general enough to be used in other use cases if need be, however.