### PR TITLE
Add `--check` support to EOF and Trailing Whitespace fixers

### DIFF
--- a/tests/end_of_file_fixer_test.py
+++ b/tests/end_of_file_fixer_test.py
@@ -40,3 +40,15 @@ def test_integration(input_s, expected_retval, output, tmpdir):
 
     assert file_output == output
     assert ret == expected_retval
+
+
+@pytest.mark.parametrize(('input_s', 'expected_retval', 'output'), TESTS)
+def test_integration_check(input_s, expected_retval, output, tmpdir):
+    path = tmpdir.join('file.txt')
+    path.write_binary(input_s)
+
+    ret = main(['--check', path.strpath])
+    file_output = path.read_binary()
+
+    assert file_output == input_s
+    assert ret == expected_retval

--- a/tests/trailing_whitespace_fixer_test.py
+++ b/tests/trailing_whitespace_fixer_test.py
@@ -20,6 +20,20 @@ def test_fixes_trailing_whitespace(input_s, expected, tmpdir):
     assert path.read() == expected
 
 
+@pytest.mark.parametrize(
+    ('input_s'),
+    (
+        ('foo \nbar \n'),
+        ('bar\t\nbaz\t\n'),
+    ),
+)
+def test_check(input_s, tmpdir):
+    path = tmpdir.join('file.md')
+    path.write(input_s)
+    assert main(('--check', path.strpath,)) == 1
+    assert path.read() == input_s
+
+
 def test_ok_no_newline_end_of_file(tmpdir):
     filename = tmpdir.join('f')
     filename.write_binary(b'foo\nbar')


### PR DESCRIPTION
This change adds an advisory mode via `--check` that only warns of
formatting issues with files, but does not address them.

This support is desirable because--while I don't mind the automagic
changes when done in a mechanical way--some individuals who I
described the current behavior of these fixers to were a bit uneasy
about the magic that went along with them. Adding `--check` so
others can opt out (similar to `black --check`) is a compromise on
this front.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>