### PR TITLE
Add shellcheck hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -179,6 +179,14 @@
     entry: requirements-txt-fixer
     language: python
     files: requirements.*\.txt$
+-   id: shellcheck
+    name: shellcheck
+    description: Test shell scripts with shellcheck
+    entry: shellcheck
+    language: python
+    types: [shell]
+    additional_dependencies: [shellcheck-py]
+    require_serial: true # shellcheck can detect sourcing this way
 -   id: sort-simple-yaml
     name: Sort simple YAML files
     language: python

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Add this to your `.pre-commit-config.yaml`
     - `--no-sort-keys` - when autofixing, retain the original key ordering (instead of sorting the keys)
     - `--top-keys comma,separated,keys` - Keys to keep at the top of mappings.
 - `requirements-txt-fixer` - Sorts entries in requirements.txt and removes incorrect entry for `pkg-resources==0.0.0`
+- `shellcheck` - Test shell scripts with shellcheck
 - `sort-simple-yaml` - Sorts simple YAML files which consist only of top-level
   keys, preserving comments and blocks.
 


### PR DESCRIPTION
Allows easy enablement of shellcheck without adding an extra git cloning step.