### PR TITLE
hotfix: the user may be define an extra arguments for a removed hook

### DIFF
--- a/pre_commit_hooks/removed.py
+++ b/pre_commit_hooks/removed.py
@@ -5,7 +5,7 @@ from typing import Sequence
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     argv = argv if argv is not None else sys.argv[1:]
-    hookid, new_hookid, url = argv
+    hookid, new_hookid, url = argv[:3]
     raise SystemExit(
         f'`{hookid}` has been removed -- use `{new_hookid}` from {url}',
     )

--- a/tests/removed_test.py
+++ b/tests/removed_test.py
@@ -8,6 +8,7 @@ def test_always_fails():
         main((
             'autopep8-wrapper', 'autopep8',
             'https://github.com/pre-commit/mirrors-autopep8',
+            '--foo', 'bar',
         ))
     msg, = excinfo.value.args
     assert msg == (


### PR DESCRIPTION
this resolve #485 