### PR TITLE
debug-statements: Add "pydevd_pycharm" to list of debug statements

### DIFF
--- a/pre_commit_hooks/debug_statement_hook.py
+++ b/pre_commit_hooks/debug_statement_hook.py
@@ -7,7 +7,16 @@ from typing import Optional
 from typing import Sequence
 
 
-DEBUG_STATEMENTS = {'pdb', 'ipdb', 'pudb', 'q', 'rdb', 'rpdb', 'wdb'}
+DEBUG_STATEMENTS = {
+    'ipdb',
+    'pdb',
+    'pudb',
+    'pydevd_pycharm',
+    'q',
+    'rdb',
+    'rpdb',
+    'wdb',
+}
 
 
 class Debug(NamedTuple):


### PR DESCRIPTION
This commit adds support for `pydevd_pycharm` debug statements in the `debug-statements`-Hook. I've also sorted the list in alphabetically order as it grows over time (see https://github.com/pre-commit/pre-commit-hooks/commit/43bfa05e8946f394e6967c63cad8875685d4c6b6 for example).

Tested locally on my machine:

```
❯ pre-commit run debug-statements -a
Debug Statements (Python)................................................Failed
- hook id: debug-statements
- exit code: 1

my_python_file.py:221:12 - pydevd_pycharm imported

```