### PR TITLE
Add missing ruamel.yaml test dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 covdefaults
 coverage
 pytest
+ruamel.yaml


### PR DESCRIPTION
Fixes this issue:

```
pre_commit_hooks/check_yaml.py:8: in <module>
    import ruamel.yaml
E   ModuleNotFoundError: No module named 'ruamel'
```