### PR TITLE
no-commit-to-branch: Add 'main' to branches blocked by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Assert that files in tests/ end in `_test.py`.
 #### `no-commit-to-branch`
 Protect specific branches from direct checkins.
   - Use `args: [--branch, staging, --branch, master]` to set the branch.
-    `master` is the default if no branch argument is set.
+    Both `master` and `main` are protected by default if no branch argument is set.
   - `-b` / `--branch` may be specified multiple times to protect multiple
     branches.
   - `-p` / `--pattern` can be used to protect branches that match a supplied regex

--- a/pre_commit_hooks/no_commit_to_branch.py
+++ b/pre_commit_hooks/no_commit_to_branch.py
@@ -38,7 +38,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    protected = frozenset(args.branch or ('master',))
+    protected = frozenset(args.branch or ('master', 'main'))
     patterns = frozenset(args.pattern or ())
     return int(is_on_branch(protected, patterns))
 

--- a/tests/no_commit_to_branch_test.py
+++ b/tests/no_commit_to_branch_test.py
@@ -67,3 +67,10 @@ def test_not_on_a_branch(temp_git_dir):
         cmd_output('git', 'checkout', head)
         # we're not on a branch!
         assert main(()) == 0
+
+
+@pytest.mark.parametrize('branch_name', ('master', 'main'))
+def test_default_branch_names(temp_git_dir, branch_name):
+    with temp_git_dir.as_cwd():
+        cmd_output('git', 'checkout', '-b', branch_name)
+        assert main(()) == 1


### PR DESCRIPTION
It's becoming more common to have the primary git branch be called `main` instead of `master` now. With GitHub now making it the [default](https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/) and making it [easier](https://github.com/github/renaming) to transition across, we've started noticing it more in other repositories, and started transferring our repositories over to it.

However, a stage that we missed in several cases was updating the pre-commit hook for `no-commit-to-branch` to block the new name, as we had relied on the default behaviour before.

This patch updates the default behaviour so both `master` and `main` are blocked by default.

~Along with this, I found that all of the tests for this hook failed by default on my machine - as part of moving my muscle memory I had set git's global `init.defaultBranch=main`. This only seems to exist from 2.28, while pre-commit lists 2.24 as a requirement for tests - but git seems to ignore (or set but not use) unrecognised configurations, so this should be safe for all targets.~

~_Side note: I couldn't find any guidelines for what formatting you want in this repo, and flake8 complained about the now-longer git call in the test configuration, so I wrote it in black-style._~