### PR TITLE
Override global git branch name for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,5 +6,12 @@ from pre_commit_hooks.util import cmd_output
 @pytest.fixture
 def temp_git_dir(tmpdir):
     git_dir = tmpdir.join('gits')
-    cmd_output('git', 'init', '--', str(git_dir))
+    cmd_output(
+        'git',
+        '-c',
+        'init.defaultBranch=master',
+        'init',
+        '--',
+        str(git_dir),
+    )
     yield git_dir


### PR DESCRIPTION
The tests for `no-commit-to-branch` all depend on the default branch name being `master`. However, there is a configuration value `git config --global init.defaultBranch` which allows you to change this - I had this set to `main`, which caused all the `no-commit-to-branch` tests to fail. I imagine others might have this set, though this could just be a local environment issue not-worthy of patching in the main codebase.

This patch explicitly overrides the configuration value when creating the test repo in tests, so that they will still pass - but without altering the tests.

An alternative, and more general way to do this might be:
```
GIT_CONFIG_NOGLOBAL=1 HOME= XDG_CONFIG_HOME= git init -- <path>
```
to suppress _all_ user/systemwide configurations. This is a bit of a blunt hammer though and I'm wary of what else it might affect (first thing that comes to mind is test commits from not having an author set....).

_Formatting note: Flake8 complained about the new line length. I couldn't find any description of preferred formatting styles so used black-style-wrapping. Happy to alter/be altered._