### PR TITLE
Check for diff3-style merge conflict artifacts.

### DIFF
--- a/pre_commit_hooks/check_merge_conflict.py
+++ b/pre_commit_hooks/check_merge_conflict.py
@@ -7,6 +7,7 @@ from typing import Sequence
 CONFLICT_PATTERNS = [
     b'<<<<<<< ',
     b'======= ',
+    b'||||||| ',
     b'=======\n',
     b'>>>>>>> ',
 ]

--- a/pre_commit_hooks/check_merge_conflict.py
+++ b/pre_commit_hooks/check_merge_conflict.py
@@ -7,8 +7,9 @@ from typing import Sequence
 CONFLICT_PATTERNS = [
     b'<<<<<<< ',
     b'======= ',
-    b'||||||| ',
     b'=======\n',
+    b'||||||| ',
+    b'|||||||\n',
     b'>>>>>>> ',
 ]
 

--- a/tests/check_merge_conflict_test.py
+++ b/tests/check_merge_conflict_test.py
@@ -129,8 +129,32 @@ def test_does_not_care_when_not_in_a_merge(tmpdir):
     f.write_binary(b'problem\n=======\n')
     assert main([str(f.realpath())]) == 0
 
+    f = tmpdir.join('README.md')
+    f.write_binary(b'problem\n======= \n')
+    assert main([str(f.realpath())]) == 0
+
+    f = tmpdir.join('README.md')
+    f.write_binary(b'problem\n|||||||\n')
+    assert main([str(f.realpath()), '--assume-in-merge']) == 0
+
+    f = tmpdir.join('README.md')
+    f.write_binary(b'problem\n||||||| \n')
+    assert main([str(f.realpath()), '--assume-in-merge']) == 0
+
 
 def test_care_when_assumed_merge(tmpdir):
     f = tmpdir.join('README.md')
     f.write_binary(b'problem\n=======\n')
+    assert main([str(f.realpath()), '--assume-in-merge']) == 1
+
+    f = tmpdir.join('README.md')
+    f.write_binary(b'problem\n======= \n')
+    assert main([str(f.realpath()), '--assume-in-merge']) == 1
+
+    f = tmpdir.join('README.md')
+    f.write_binary(b'problem\n|||||||\n')
+    assert main([str(f.realpath()), '--assume-in-merge']) == 1
+
+    f = tmpdir.join('README.md')
+    f.write_binary(b'problem\n||||||| \n')
     assert main([str(f.realpath()), '--assume-in-merge']) == 1


### PR DESCRIPTION
I noticed that [the test suite](https://github.com/pre-commit/pre-commit-hooks/blob/master/tests/check_merge_conflict_test.py#L49) checks for `diff3`-style merge conflicts, but the [actual hook](https://github.com/pre-commit/pre-commit-hooks/blob/master/pre_commit_hooks/check_merge_conflict.py#L8-L11) does not. Seems like an oversight?