### PR TITLE
Update flake8 redirect to new upstream home

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -158,8 +158,8 @@
     types: [python]
 -   id: flake8
     name: Flake8 (removed)
-    description: (removed) use gitlab.com/pycqa/flake8 instead.
-    entry: pre-commit-hooks-removed flake8 flake8 https://gitlab.com/pycqa/flake8
+    description: (removed) use github.com/PyCQA/flake8 instead.
+    entry: pre-commit-hooks-removed flake8 flake8 https://github.com/PyCQA/flake8
     language: python
     always_run: true
     pass_filenames: false
@@ -188,8 +188,8 @@
     always_run: true
 -   id: pyflakes
     name: Pyflakes (removed)
-    description: (removed) use gitlab.com/pycqa/flake8 instead.
-    entry: pre-commit-hooks-removed pyflakes flake8 https://gitlab.com/pycqa/flake8
+    description: (removed) use github.com/PyCQA/flake8 instead.
+    entry: pre-commit-hooks-removed pyflakes flake8 https://github.com/PyCQA/flake8
     language: python
     always_run: true
     pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Trims trailing whitespace.
 - `autopep8-wrapper`: instead use
   [mirrors-autopep8](https://github.com/pre-commit/mirrors-autopep8)
 - `pyflakes`: instead use `flake8`
-- `flake8`: instead use [upstream flake8](https://gitlab.com/pycqa/flake8)
+- `flake8`: instead use [upstream flake8](https://github.com/PyCQA/flake8)
 - `check-byte-order-marker`: instead use fix-byte-order-marker
 
 ### As a standalone package


### PR DESCRIPTION
Standardise https://gitlab.com/pycqa/flake8 -> https://github.com/PyCQA/flake8