### PR TITLE
Allow TOML 1.0.0 syntax in check-toml

### DIFF
--- a/pre_commit_hooks/check_toml.py
+++ b/pre_commit_hooks/check_toml.py
@@ -2,7 +2,7 @@ import argparse
 from typing import Optional
 from typing import Sequence
 
-import toml
+import tomli
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -12,11 +12,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     retval = 0
     for filename in args.filenames:
-        try:
-            toml.load(filename)
-        except toml.TomlDecodeError as exc:
-            print(f'{filename}: {exc}')
-            retval = 1
+        with open(filename, encoding='utf-8') as f:
+            try:
+                tomli.load(f)
+            except tomli.TOMLDecodeError as exc:
+                print(f'{filename}: {exc}')
+                retval = 1
     return retval
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 packages = find:
 install_requires =
     ruamel.yaml>=0.15
-    toml
+    tomli
 python_requires = >=3.6.1
 
 [options.packages.find]

--- a/tests/check_toml_test.py
+++ b/tests/check_toml_test.py
@@ -23,6 +23,9 @@ title = "TOML Example"
 [owner]
 name = "John"
 dob = 1979-05-27T07:32:00-08:00 # First class dates
+
+["toml-1.0.0-compat"]
+heterogeneous-array = [1, "2"]
 """,
     )
     ret = main((str(filename),))


### PR DESCRIPTION
`check-toml` fails with new TOML 1.0.0 syntax. This changes the TOML parser used to a spec v1.0.0 compatible one. Disclaimer: the [parser](https://github.com/hukkinj1/tomli) used is written by me.