### PR TITLE
optimize check_case_conflict.parents

### DIFF
--- a/pre_commit_hooks/check_case_conflict.py
+++ b/pre_commit_hooks/check_case_conflict.py
@@ -1,5 +1,4 @@
 import argparse
-import os.path
 from typing import Iterable
 from typing import Iterator
 from typing import Optional

--- a/pre_commit_hooks/check_case_conflict.py
+++ b/pre_commit_hooks/check_case_conflict.py
@@ -15,10 +15,11 @@ def lower_set(iterable: Iterable[str]) -> Set[str]:
 
 
 def parents(file: str) -> Iterator[str]:
-    file = os.path.dirname(file)
-    while file:
-        yield file
-        file = os.path.dirname(file)
+    path_parts = file.split('/')
+    path_parts.pop()
+    while path_parts:
+        yield '/'.join(path_parts)
+        path_parts.pop()
 
 
 def directories_for(files: Set[str]) -> Set[str]:


### PR DESCRIPTION
fixes #625

performance for this approach on my team's repo:
```
λ py test.py
         10001077 function calls in 4.023 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.039    0.039    4.023    4.023 <string>:1(<module>)
        4    0.000    0.000    0.000    0.000 _weakrefset.py:38(_remove)
        4    0.000    0.000    0.000    0.000 _weakrefset.py:81(add)
        3    0.000    0.000    0.289    0.096 check_case_conflict.py:13(lower_set)
        3    0.192    0.064    0.289    0.096 check_case_conflict.py:14(<setcomp>)
  3189661    1.037    0.000    2.010    0.000 check_case_conflict.py:17(parents)
        2    0.000    0.000    2.817    1.409 check_case_conflict.py:25(directories_for)
        2    0.807    0.404    2.817    1.409 check_case_conflict.py:26(<setcomp>)
        1    0.146    0.146    3.984    3.984 check_case_conflict.py:29(find_conflicting_filenames)
        2    0.000    0.000    0.000    0.000 subprocess.py:1023(_internal_poll)
        2    0.000    0.000    0.021    0.011 subprocess.py:1040(wait)
        2    0.000    0.000    0.608    0.304 subprocess.py:1067(_communicate)
       22    0.000    0.000    0.000    0.000 subprocess.py:179(Close)
```

So it's 4 seconds with this approach vs 20 seconds with the previous approach.
