### PR TITLE
Fix false positives of check-executables-have-shebangs

### DIFF
--- a/pre_commit_hooks/check_executables_have_shebangs.py
+++ b/pre_commit_hooks/check_executables_have_shebangs.py
@@ -16,16 +16,11 @@ EXECUTABLE_VALUES = frozenset(('1', '3', '5', '7'))
 
 
 def check_executables(paths: List[str]) -> int:
-    if sys.platform == 'win32':  # pragma: win32 cover
-        return _check_git_filemode(paths)
-    else:  # pragma: win32 no cover
-        retv = 0
-        for path in paths:
-            if not has_shebang(path):
-                _message(path)
-                retv = 1
-
-        return retv
+    # Even if this hook is configured to be called only on files flagged
+    # executable by identify, we must check the real filemode known to Git
+    # because some filesystems force the executable bit (e.g. fat32 under
+    # Linux).
+    return _check_git_filemode(paths)
 
 
 class GitLsFile(NamedTuple):

--- a/tests/check_executables_have_shebangs_test.py
+++ b/tests/check_executables_have_shebangs_test.py
@@ -1,19 +1,13 @@
 import os
-import sys
 
 import pytest
 
 from pre_commit_hooks import check_executables_have_shebangs
+from pre_commit_hooks.check_executables_have_shebangs import has_shebang
 from pre_commit_hooks.check_executables_have_shebangs import main
 from pre_commit_hooks.util import cmd_output
 
-skip_win32 = pytest.mark.skipif(
-    sys.platform == 'win32',
-    reason="non-git checks aren't relevant on windows",
-)
 
-
-@skip_win32  # pragma: win32 no cover
 @pytest.mark.parametrize(
     'content', (
         b'#!/bin/bash\nhello world\n',
@@ -25,10 +19,9 @@ skip_win32 = pytest.mark.skipif(
 def test_has_shebang(content, tmpdir):
     path = tmpdir.join('path')
     path.write(content, 'wb')
-    assert main((str(path),)) == 0
+    assert has_shebang(str(path))
 
 
-@skip_win32  # pragma: win32 no cover
 @pytest.mark.parametrize(
     'content', (
         b'',
@@ -38,12 +31,10 @@ def test_has_shebang(content, tmpdir):
         '☃'.encode(),
     ),
 )
-def test_bad_shebang(content, tmpdir, capsys):
+def test_bad_shebang(content, tmpdir):
     path = tmpdir.join('path')
     path.write(content, 'wb')
-    assert main((str(path),)) == 1
-    _, stderr = capsys.readouterr()
-    assert stderr.startswith(f'{path}: marked executable but')
+    assert not has_shebang(str(path))
 
 
 def test_check_git_filemode_passing(tmpdir):


### PR DESCRIPTION
`check-executables-have-shebangs` needs to check the actual file mode known to Git and avoid relying only on the filesystem permissions, because some filesystems force the executable bit on every file (e.g. fat32 on Linux).