### PR TITLE
Fix "while scanning a plain scalar found unexpected ':'"

### DIFF
--- a/pre_commit_hooks/check_yaml.py
+++ b/pre_commit_hooks/check_yaml.py
@@ -7,7 +7,7 @@ from typing import Sequence
 
 import ruamel.yaml
 
-yaml = ruamel.yaml.YAML(typ='safe')
+yaml = ruamel.yaml.YAML(typ='safe', pure=True)
 
 
 def _exhaust(gen: Generator[str, None, None]) -> None:

--- a/testing/resources/ok_yaml.yaml
+++ b/testing/resources/ok_yaml.yaml
@@ -1,1 +1,2 @@
 im: ok yaml
+test: {site: http://example.com}


### PR DESCRIPTION
I use `check-yaml` hook to validate YAML files in project.
The `pnpm` generate such sort of construction (in `pnpm-lock.yaml`):

```
github.com/account_name/package_name/md5:
  resolution: {tarball: https://codeload.github.com/account_name/package_name/tar.gz/md5}

```
And on this file the `check-yaml` raises validation error:

```
while scanning a plain scalar
  in "test.yml", line 2, column 25
found unexpected ':'
  in "test.yml", line 2, column 30
```