### PR TITLE
Allow pretty-format-json module to unify and/or sort list values 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ the following commandline options:
   - `--indent ...` - Control the indentation (either a number for a number of spaces or a string of whitespace).  Defaults to 2 spaces.
   - `--no-ensure-ascii` preserve unicode characters instead of converting to escape sequences
   - `--no-sort-keys` - when autofixing, retain the original key ordering (instead of sorting the keys)
+  - `--sort-values comma,separated,keys` - Keys whose list values shall be sorted. Only applied to lists with primitive values.
   - `--top-keys comma,separated,keys` - Keys to keep at the top of mappings.
+  - `--unique-values comma,separated,keys` - Keys whose list values shall be made unique. Only applied to lists with primitive values.
 
 #### `requirements-txt-fixer`
 Sorts entries in requirements.txt and removes incorrect entry for `pkg-resources==0.0.0`

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -84,9 +84,8 @@ def _get_pretty_format(
         transformed_pairs = transform_top_keys(transformed_pairs)
         return dict(transformed_pairs)
 
-    load = json.loads(contents, object_pairs_hook=pairs_first)
     json_pretty = json.dumps(
-        load,
+        json.loads(contents, object_pairs_hook=pairs_first),
         indent=indent,
         ensure_ascii=ensure_ascii,
     )

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -48,8 +48,8 @@ def _get_pretty_format(
             ):
                 # No sorting requested
                 # Value is no list, sorting makes no sense
-                # Only sort if all list entries are of the same type
-                # Only sort if all list entries are no list or mapping
+                # Not all list entries are of the same type
+                # One or more list entries are list or mapping
                 transformed_pairs.append((key, value))
                 continue
             transformed_pairs.append((key, sorted(value)))
@@ -71,8 +71,8 @@ def _get_pretty_format(
             ):
                 # No unification requested
                 # Value is no list, unification makes no sense
-                # Only unify if all list entries are of the same type
-                # Only unify if all list entries are no list or mapping
+                # Not all list entries are of the same type
+                # One or more list entries are list or mapping
                 transformed_pairs.append((key, value))
                 continue
             transformed_pairs.append((key, list(dict.fromkeys(value))))

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -20,7 +20,9 @@ def _get_pretty_format(
         top_keys: Sequence[str] = (),
         unique_values: Sequence[str] = (),
 ) -> str:
-    def transform_top_keys(pairs: Sequence[Tuple[str, Any]]) -> Sequence[Tuple[str, Any]]:
+    def transform_top_keys(
+        pairs: Sequence[Tuple[str, Any]],
+    ) -> Sequence[Tuple[str, Any]]:
         transformed_pairs = []
         before = [pair for pair in pairs if pair[0] in top_keys]
         before = sorted(before, key=lambda x: top_keys.index(x[0]))
@@ -31,32 +33,46 @@ def _get_pretty_format(
         transformed_pairs.extend(after)
         return transformed_pairs
 
-    def transform_sort_values(pairs: Sequence[Tuple[str, Any]]) -> Sequence[Tuple[str, Any]]:
+    def transform_sort_values(
+        pairs: Sequence[Tuple[str, Any]],
+    ) -> Sequence[Tuple[str, Any]]:
         if not sort_values:
             return pairs
         transformed_pairs = []
         for (key, value) in pairs:
-            if (key not in sort_values  # No sorting requested
-                or not isinstance(value, List)  # Value is no list, sorting makes no sense
-                or len(set([type(x) for x in value])) > 1  # Only sort if all list entries are of the same type
-                or any([isinstance(x, (List, Mapping)) for x in value])  # Only sort if all list entries are no list or mapping
+            if (
+                key not in sort_values or
+                not isinstance(value, List) or
+                len({type(x) for x in value}) > 1 or
+                    any([isinstance(x, (List, Mapping)) for x in value])
             ):
+                # No sorting requested
+                # Value is no list, sorting makes no sense
+                # Only sort if all list entries are of the same type
+                # Only sort if all list entries are no list or mapping
                 transformed_pairs.append((key, value))
                 continue
             transformed_pairs.append((key, sorted(value)))
         return transformed_pairs
 
-    def transform_unique_values(pairs: Sequence[Tuple[str, Any]]) -> Sequence[Tuple[str, Any]]:
+    def transform_unique_values(
+        pairs: Sequence[Tuple[str, Any]],
+    ) -> Sequence[Tuple[str, Any]]:
         if not unique_values:
             return pairs
         print(pairs)
         transformed_pairs = []
         for (key, value) in pairs:
-            if (key not in unique_values  # No unification requested
-                or not isinstance(value, List)  # Value is no list, unification makes no sense
-                or len(set([type(x) for x in value])) > 1  # Only unify if all list entries are of the same type
-                or any([isinstance(x, (List, Mapping)) for x in value])  # Only unify if all list entries are no list or mapping
+            if (
+                key not in unique_values or
+                    not isinstance(value, List) or
+                    len({type(x) for x in value}) > 1 or
+                    any([isinstance(x, (List, Mapping)) for x in value])
             ):
+                # No unification requested
+                # Value is no list, unification makes no sense
+                # Only unify if all list entries are of the same type
+                # Only unify if all list entries are no list or mapping
                 transformed_pairs.append((key, value))
                 continue
             transformed_pairs.append((key, list(dict.fromkeys(value))))
@@ -68,7 +84,7 @@ def _get_pretty_format(
         transformed_pairs = transform_top_keys(transformed_pairs)
         return dict(transformed_pairs)
 
-    load=json.loads(contents, object_pairs_hook=pairs_first)
+    load = json.loads(contents, object_pairs_hook=pairs_first)
     json_pretty = json.dumps(
         load,
         indent=indent,

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -36,20 +36,11 @@ def _get_pretty_format(
             return pairs
         transformed_pairs = []
         for (key, value) in pairs:
-            if key not in sort_values:
-                # No sorting requested
-                transformed_pairs.append((key, value))
-                continue
-            if not isinstance(value, List):
-                # Value is no list, sorting makes no sense
-                transformed_pairs.append((key, value))
-                continue
-            if len(set([type(x) for x in value])) > 1:
-                # Only sort if all list entries are of the same type
-                transformed_pairs.append((key, value))
-                continue
-            if any([isinstance(x, (List, Mapping)) for x in value]):
-                # Only sort if all list entries are no list or mapping
+            if (key not in sort_values  # No sorting requested
+                or not isinstance(value, List)  # Value is no list, sorting makes no sense
+                or len(set([type(x) for x in value])) > 1  # Only sort if all list entries are of the same type
+                or any([isinstance(x, (List, Mapping)) for x in value])  # Only sort if all list entries are no list or mapping
+            ):
                 transformed_pairs.append((key, value))
                 continue
             transformed_pairs.append((key, sorted(value)))
@@ -61,19 +52,11 @@ def _get_pretty_format(
         print(pairs)
         transformed_pairs = []
         for (key, value) in pairs:
-            if key not in unique_values:
-                transformed_pairs.append((key, value))
-                continue
-            if not isinstance(value, List):
-                # Value is no list, sorting makes no sense
-                transformed_pairs.append((key, value))
-                continue
-            if len(set([type(x) for x in value])) > 1:
-                # Only sort if all list entries are of the same type
-                transformed_pairs.append((key, value))
-                continue
-            if any([isinstance(x, (List, Mapping)) for x in value]):
-                # Only sort if all list entries are no list or mapping
+            if (key not in unique_values  # No unification requested
+                or not isinstance(value, List)  # Value is no list, unification makes no sense
+                or len(set([type(x) for x in value])) > 1  # Only unify if all list entries are of the same type
+                or any([isinstance(x, (List, Mapping)) for x in value])  # Only unify if all list entries are no list or mapping
+            ):
                 transformed_pairs.append((key, value))
                 continue
             transformed_pairs.append((key, list(dict.fromkeys(value))))

--- a/testing/resources/sort_values_pretty_formatted_json.json
+++ b/testing/resources/sort_values_pretty_formatted_json.json
@@ -1,0 +1,25 @@
+{
+  "foo": "bar",
+  "sort_list": [
+    34,
+    2,
+    234
+  ],
+  "wont_sort_list": [
+    34,
+    2,
+    ""
+  ],
+  "sub_dict": {
+    "sub_sub_dict": {
+      "sort_sub_sub_sub_dict": [
+        "foo",
+        "bar",
+        "bar",
+        "baz"
+      ],
+      "do_not_sort": []
+    }
+  },
+  "blah": null
+}

--- a/testing/resources/unique_values_pretty_formatted_json.json
+++ b/testing/resources/unique_values_pretty_formatted_json.json
@@ -1,0 +1,25 @@
+{
+  "unique_list": [
+    234,
+    34,
+    2,
+    234
+  ],
+  "sub_dict": {
+    "sub_list": [
+      "foo",
+      "foo",
+      {
+        "sub_sub_dict_entry": "sub_sub_dict_entry_value"
+      },
+      "bar",
+      [
+        1,
+        2,
+        3
+      ]
+    ],
+    "sub_list_2": "sub_list_2_value"
+  },
+  "foo": "bar"
+}

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -106,6 +106,58 @@ def test_badfile_main():
     assert ret == 1
 
 
+def test_sort_values_get_pretty_format():
+    ret = main((
+        '--no-sort-keys', '--sort-values=sort_list,wont_sort_list,sort_sub_sub_sub_dict', get_resource_path('sort_values_pretty_formatted_json.json')))
+    assert ret == 1
+
+
+def test_sort_values_diffing_output(capsys):
+    resource_path = get_resource_path('sort_values_pretty_formatted_json.json')
+    expected_retval = 1
+    a = os.path.join('a', resource_path)
+    b = os.path.join('b', resource_path)
+    expected_out = f'''\
+--- {a}
++++ {b}
+@@ -1,8 +1,8 @@
+ {{
+   "foo": "bar",
+   "sort_list": [
++    2,
+     34,
+-    2,
+     234
+   ],
+   "wont_sort_list": [
+@@ -13,10 +13,10 @@
+   "sub_dict": {{
+     "sub_sub_dict": {{
+       "sort_sub_sub_sub_dict": [
+-        "foo",
+         "bar",
+         "bar",
+-        "baz"
++        "baz",
++        "foo"
+       ],
+       "do_not_sort": []
+     }}
+'''
+    actual_retval = main(['--no-sort-keys', '--sort-values=sort_list,wont_sort_list,sort_sub_sub_sub_dict', resource_path])
+    actual_out, actual_err = capsys.readouterr()
+
+    assert actual_retval == expected_retval
+    assert actual_out == expected_out
+    assert actual_err == ''
+
+
+def test_uniquevalues_get_pretty_format():
+    ret = main([
+        '--no-sort-keys', '--unique-values=unique_list,sub_list', get_resource_path('unique_values_pretty_formatted_json.json')])
+    assert ret == 1
+
+
 def test_diffing_output(capsys):
     resource_path = get_resource_path('not_pretty_formatted_json.json')
     expected_retval = 1

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -107,8 +107,11 @@ def test_badfile_main():
 
 
 def test_sort_values_get_pretty_format():
-    ret = main((
-        '--no-sort-keys', '--sort-values=sort_list,wont_sort_list,sort_sub_sub_sub_dict', get_resource_path('sort_values_pretty_formatted_json.json')))
+    ret = main([
+        '--no-sort-keys',
+        '--sort-values=sort_list,wont_sort_list,sort_sub_sub_sub_dict',
+        get_resource_path('sort_values_pretty_formatted_json.json'),
+    ])
     assert ret == 1
 
 
@@ -144,7 +147,11 @@ def test_sort_values_diffing_output(capsys):
        "do_not_sort": []
      }}
 '''
-    actual_retval = main(['--no-sort-keys', '--sort-values=sort_list,wont_sort_list,sort_sub_sub_sub_dict', resource_path])
+    actual_retval = main([
+        '--no-sort-keys',
+        '--sort-values=sort_list,wont_sort_list,sort_sub_sub_sub_dict',
+        resource_path,
+    ])
     actual_out, actual_err = capsys.readouterr()
 
     assert actual_retval == expected_retval
@@ -154,7 +161,10 @@ def test_sort_values_diffing_output(capsys):
 
 def test_uniquevalues_get_pretty_format():
     ret = main([
-        '--no-sort-keys', '--unique-values=unique_list,sub_list', get_resource_path('unique_values_pretty_formatted_json.json')])
+        '--no-sort-keys',
+        '--unique-values=unique_list,sub_list',
+        get_resource_path('unique_values_pretty_formatted_json.json'),
+    ])
     assert ret == 1
 
 


### PR DESCRIPTION
This PR adds the ability to the pretty-format-json module to sort and/or unify list values, given their keys.

A use case for this are lists of resources and their permissions, which - for readability - should be sorted and unified to easily identify duplicates.