### PR TITLE
Fix failing filesystem case dependent tests on MacOS

### DIFF
--- a/tests/check_case_conflict_test.py
+++ b/tests/check_case_conflict_test.py
@@ -13,7 +13,7 @@ skip_win32 = pytest.mark.skipif(
     reason='case conflicts between directories and files',
 )
 
-skip_darwin = pytest.mark_skipif(
+skip_darwin = pytest.mark.skipif(
     sys.platform == 'darwin',
     reason='case conflicts between directories and files',
 )

--- a/tests/check_case_conflict_test.py
+++ b/tests/check_case_conflict_test.py
@@ -13,6 +13,11 @@ skip_win32 = pytest.mark.skipif(
     reason='case conflicts between directories and files',
 )
 
+skip_darwin = pytest.mark_skipif(
+    sys.platform == "darwin",
+    reason = 'case conflicts between directories and files'
+)
+
 
 def test_parents():
     assert set(parents('a')) == set()
@@ -45,6 +50,7 @@ def test_adding_something_with_conflict(temp_git_dir):
 
 
 @skip_win32  # pragma: win32 no cover
+@skip_darwin # pragma: MacOS no cover
 def test_adding_files_with_conflicting_directories(temp_git_dir):
     with temp_git_dir.as_cwd():
         temp_git_dir.mkdir('dir').join('x').write('foo')
@@ -55,6 +61,7 @@ def test_adding_files_with_conflicting_directories(temp_git_dir):
 
 
 @skip_win32  # pragma: win32 no cover
+@skip_darwin # pragma: MacOS no cover
 def test_adding_files_with_conflicting_deep_directories(temp_git_dir):
     with temp_git_dir.as_cwd():
         temp_git_dir.mkdir('x').mkdir('y').join('z').write('foo')
@@ -65,6 +72,7 @@ def test_adding_files_with_conflicting_deep_directories(temp_git_dir):
 
 
 @skip_win32  # pragma: win32 no cover
+@skip_darwin # pragma: MacOS no cover
 def test_adding_file_with_conflicting_directory(temp_git_dir):
     with temp_git_dir.as_cwd():
         temp_git_dir.mkdir('dir').join('x').write('foo')
@@ -95,6 +103,7 @@ def test_file_conflicts_with_committed_file(temp_git_dir):
 
 
 @skip_win32  # pragma: win32 no cover
+@skip_darwin # pragma: MacOS no cover
 def test_file_conflicts_with_committed_dir(temp_git_dir):
     with temp_git_dir.as_cwd():
         temp_git_dir.mkdir('dir').join('x').write('foo')

--- a/tests/check_case_conflict_test.py
+++ b/tests/check_case_conflict_test.py
@@ -14,8 +14,8 @@ skip_win32 = pytest.mark.skipif(
 )
 
 skip_darwin = pytest.mark_skipif(
-    sys.platform == "darwin",
-    reason = 'case conflicts between directories and files'
+    sys.platform == 'darwin',
+    reason='case conflicts between directories and files',
 )
 
 
@@ -50,7 +50,7 @@ def test_adding_something_with_conflict(temp_git_dir):
 
 
 @skip_win32  # pragma: win32 no cover
-@skip_darwin # pragma: MacOS no cover
+@skip_darwin  # pragma: MacOS no cover
 def test_adding_files_with_conflicting_directories(temp_git_dir):
     with temp_git_dir.as_cwd():
         temp_git_dir.mkdir('dir').join('x').write('foo')
@@ -61,7 +61,7 @@ def test_adding_files_with_conflicting_directories(temp_git_dir):
 
 
 @skip_win32  # pragma: win32 no cover
-@skip_darwin # pragma: MacOS no cover
+@skip_darwin  # pragma: MacOS no cover
 def test_adding_files_with_conflicting_deep_directories(temp_git_dir):
     with temp_git_dir.as_cwd():
         temp_git_dir.mkdir('x').mkdir('y').join('z').write('foo')
@@ -72,7 +72,7 @@ def test_adding_files_with_conflicting_deep_directories(temp_git_dir):
 
 
 @skip_win32  # pragma: win32 no cover
-@skip_darwin # pragma: MacOS no cover
+@skip_darwin  # pragma: MacOS no cover
 def test_adding_file_with_conflicting_directory(temp_git_dir):
     with temp_git_dir.as_cwd():
         temp_git_dir.mkdir('dir').join('x').write('foo')
@@ -103,7 +103,7 @@ def test_file_conflicts_with_committed_file(temp_git_dir):
 
 
 @skip_win32  # pragma: win32 no cover
-@skip_darwin # pragma: MacOS no cover
+@skip_darwin  # pragma: MacOS no cover
 def test_file_conflicts_with_committed_dir(temp_git_dir):
     with temp_git_dir.as_cwd():
         temp_git_dir.mkdir('dir').join('x').write('foo')


### PR DESCRIPTION
When we try to compile pre-commit hooks with python dependencies on MacOS using https://github.com/cachix/pre-commit-hooks.nix , we get errors due to tests that depend on case sensitive filesystem failing. Adding same skip annotations for MacOS/Darwin as we have for Windows.

See here for the error output from nix build: https://gist.github.com/bbhoss/dc3d098b32395b0650e79e6d6025885c