### PR TITLE
Fix check-added-large-files --enforce-all to correctly consider all git-lfs files.

### DIFF
--- a/tests/check_added_large_files_test.py
+++ b/tests/check_added_large_files_test.py
@@ -121,3 +121,16 @@ def test_enforce_allows_gitlfs(temp_git_dir, monkeypatch):  # pragma: no cover
         cmd_output('git', 'add', '--', '.')
         # With --enforce-all large files on git lfs should succeed
         assert main(('--enforce-all', '--maxkb', '9', 'f.py')) == 0
+
+
+@xfailif_no_gitlfs  # pragma: no cover
+def test_enforce_allows_gitlfs_after_commit(temp_git_dir, monkeypatch):
+    with temp_git_dir.as_cwd():
+        monkeypatch.setenv('HOME', str(temp_git_dir))
+        cmd_output('git', 'lfs', 'install')
+        temp_git_dir.join('f.py').write('a' * 10000)
+        cmd_output('git', 'lfs', 'track', 'f.py')
+        cmd_output('git', 'add', '--', '.')
+        git_commit('-am', 'foo')
+        # With --enforce-all large files on git lfs should succeed
+        assert main(('--enforce-all', '--maxkb', '9', 'f.py')) == 0


### PR DESCRIPTION
`git lfs status` only outputs status for files that are pending some git-lfs related operation.
For usage with --enforce-all, we need the list of all files that are tracked. Ideally, this would
be done using `git lfs ls-files`; however, that doesn't provide a parseable output option
(https://github.com/git-lfs/git-lfs/issues/4679). Therefore, this uses `git check-attr` and uses
the attribute `filter=lfs` to determine which files to consider as git-lfs files.

Fixes: https://github.com/pre-commit/pre-commit-hooks/issues/560