### PR TITLE
Suggest usable call when executable files lack shebang on Windows

### DIFF
--- a/pre_commit_hooks/check_executables_have_shebangs.py
+++ b/pre_commit_hooks/check_executables_have_shebangs.py
@@ -64,6 +64,8 @@ def _message(path: str) -> None:
         f'{path}: marked executable but has no (or invalid) shebang!\n'
         f"  If it isn't supposed to be executable, try: "
         f'`chmod -x {shlex.quote(path)}`\n'
+        f'  If on Windows, you may also need to: '
+        f'`git add --chmod=-x {shlex.quote(path)}`\n'
         f'  If it is supposed to be executable, double-check its shebang.',
         file=sys.stderr,
     )


### PR DESCRIPTION
Resolves #686 

> Some of the executable error messages suggest using chmod +/-x to toggle the executable bits. This works fine on *nix, but not on windows, and the results range from 'command not found' to doing nothing at all.
> 
> Eg: https://github.com/pre-commit/pre-commit-hooks/blob/56b4a7e506901ff86f8de5c2551bc41f8eacf717/pre_commit_hooks/check_executables_have_shebangs.py#L66
> 
> Instead, this should recommend `git add --chmod=+/-x somepath` when the hook detects it's running on windows.