### PR TITLE
Fix misleading error message

### DIFF
--- a/pre_commit_hooks/check_shebang_scripts_are_executable.py
+++ b/pre_commit_hooks/check_shebang_scripts_are_executable.py
@@ -34,7 +34,7 @@ def _message(path: str) -> None:
     print(
         f'{path}: has a shebang but is not marked executable!\n'
         f'  If it is supposed to be executable, try: '
-        f'`chmod +x {shlex.quote(path)}`\n'
+        f'`git update-index --chmod=+x {shlex.quote(path)}`\n'
         f'  If it not supposed to be executable, double-check its shebang '
         f'is wanted.\n',
         file=sys.stderr,


### PR DESCRIPTION
The command given in the previous error message only changed the local script to executable. When running pre-commit the next time, it failed again with the same error message.

The new command actually changes the script in the repository to be executable, and pre-commit runs through the next time.

See also: [Make Shell Script Committed to Git Executable](https://www.pixelninja.me/make-script-committed-to-git-executable/).