### PR TITLE
remove --fail-under from tox (covdefaults handles this)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv =
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}
-    coverage report --fail-under 100
+    coverage report
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos