### PR TITLE
Add flag to disallow a new line on JSON format.

### DIFF
--- a/pre_commit_hooks/.json
+++ b/pre_commit_hooks/.json
@@ -1,3 +1,0 @@
-{
-  "name": "victor"
-}

--- a/pre_commit_hooks/.json
+++ b/pre_commit_hooks/.json
@@ -1,0 +1,3 @@
+{
+  "name": "victor"
+}

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -14,7 +14,7 @@ def _get_pretty_format(
         ensure_ascii: bool = True,
         sort_keys: bool = True,
         top_keys: Sequence[str] = (),
-        new_line: bool = False,
+        new_line: bool = True,
 ) -> str:
     def pairs_first(pairs: Sequence[tuple[str, str]]) -> Mapping[str, str]:
         before = [pair for pair in pairs if pair[0] in top_keys]

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -98,11 +98,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         help='Ordered list of keys to keep at the top of JSON hashes',
     )
     parser.add_argument(
-        '--new-line', 
+        '--no-new-line', 
         action='store_true', 
-        dest='new_line',
+        dest='no_new_line',
         default=False, 
-        help="Add a new line at the end of the file"
+        help="Do NOT add a new line at the end of the files"
     )
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)
@@ -116,7 +116,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             pretty_contents = _get_pretty_format(
                 contents, args.indent, ensure_ascii=not args.no_ensure_ascii,
-                sort_keys=not args.no_sort_keys, top_keys=args.top_keys, new_line=args.new_line
+                sort_keys=not args.no_sort_keys, top_keys=args.top_keys, new_line=not args.no_new_line
             )
         except ValueError:
             print(

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -14,6 +14,7 @@ def _get_pretty_format(
         ensure_ascii: bool = True,
         sort_keys: bool = True,
         top_keys: Sequence[str] = (),
+        new_line: bool = False,
 ) -> str:
     def pairs_first(pairs: Sequence[tuple[str, str]]) -> Mapping[str, str]:
         before = [pair for pair in pairs if pair[0] in top_keys]
@@ -27,7 +28,7 @@ def _get_pretty_format(
         indent=indent,
         ensure_ascii=ensure_ascii,
     )
-    return f'{json_pretty}\n'
+    return f'{json_pretty}\n' if new_line else json_pretty
 
 
 def _autofix(filename: str, new_contents: str) -> None:
@@ -96,6 +97,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=[],
         help='Ordered list of keys to keep at the top of JSON hashes',
     )
+    parser.add_argument(
+        '--new-line', 
+        action='store_true', 
+        dest='new_line',
+        default=False, 
+        help="Add a new line at the end of the file"
+    )
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)
 
@@ -108,7 +116,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             pretty_contents = _get_pretty_format(
                 contents, args.indent, ensure_ascii=not args.no_ensure_ascii,
-                sort_keys=not args.no_sort_keys, top_keys=args.top_keys,
+                sort_keys=not args.no_sort_keys, top_keys=args.top_keys, new_line=args.new_line
             )
         except ValueError:
             print(

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -116,7 +116,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             pretty_contents = _get_pretty_format(
                 contents, args.indent, ensure_ascii=not args.no_ensure_ascii,
-                sort_keys=not args.no_sort_keys, top_keys=args.top_keys, new_line=not args.no_new_line,
+                sort_keys=not args.no_sort_keys, top_keys=args.top_keys,
+                new_line=not args.no_new_line,
             )
         except ValueError:
             print(


### PR DESCRIPTION
This PR adds `--no-new-line` flag to disallow a new line when formatting JSON, it's `False` by default.

Closes #720 
