### PR TITLE
Check Git core.fileMode rather than infer from OS.

### DIFF
--- a/pre_commit_hooks/check_executables_have_shebangs.py
+++ b/pre_commit_hooks/check_executables_have_shebangs.py
@@ -15,7 +15,10 @@ EXECUTABLE_VALUES = frozenset(('1', '3', '5', '7'))
 
 
 def check_executables(paths: list[str]) -> int:
-    if sys.platform == 'win32':  # pragma: win32 cover
+    fs_tracks_executable_bit = cmd_output(
+        'git', 'config', 'core.fileMode', retcode=None,
+    ).strip()
+    if fs_tracks_executable_bit == 'false':  # pragma: win32 cover
         return _check_git_filemode(paths)
     else:  # pragma: win32 no cover
         retv = 0


### PR DESCRIPTION
There was already a guard preventing the `check-executables-have-shebangs` hook from raising false positives on win32 by looking up the Git file mode rather than relying on the file mode in the file system. Git already automatically probes the file system for executable bit support. Leverage Git's [`core.fileMode` config variable](https://git-scm.com/docs/git-config#Documentation/git-config.txt-corefileMode) to prevent false positives on all file systems that don't track executable bits.

Fixes #690.