### PR TITLE
Default allow_missing_credentials flag to True

### DIFF
--- a/pre_commit_hooks/detect_aws_credentials.py
+++ b/pre_commit_hooks/detect_aws_credentials.py
@@ -107,6 +107,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         '--allow-missing-credentials',
         dest='allow_missing_credentials',
+        default=True,
         action='store_true',
         help='Allow hook to pass when no credentials are detected.',
     )


### PR DESCRIPTION
I just had to help an engineer troubleshoot this failing pre-commit hook because he had never used the AWS CLI / SDK and didn't have any AWS credentials on his local machines. IMHO, the `allow_missing_credentials` flag should default to `True`. It's hard to imagine a use case in which you would want to force someone to have AWS credentials on their local machine in order to make sure that they didn't put said AWS credentials (that are _not_ on their local machine 🙃 ) in the specified codebase.