### PR TITLE
Support checking executable bit without Git.

### DIFF
--- a/tests/check_shebang_scripts_are_executable_test.py
+++ b/tests/check_shebang_scripts_are_executable_test.py
@@ -1,11 +1,69 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from pre_commit_hooks.check_shebang_scripts_are_executable import \
     _check_git_filemode
 from pre_commit_hooks.check_shebang_scripts_are_executable import main
 from pre_commit_hooks.util import cmd_output
+
+skip_win32 = pytest.mark.xfail(
+    sys.platform == 'win32',
+    reason="non-git checks aren't relevant on windows",
+)
+
+
+@skip_win32  # pragma: win32 no cover
+@pytest.mark.parametrize(
+    'content', (
+        b'#!/bin/bash\nhello world\n',
+        b'#!/usr/bin/env python3.10',
+        b'#!python',
+        '#!☃'.encode(),
+    ),
+)
+def test_executable_shebang(content, tmpdir):
+    path = tmpdir.join('path')
+    path.write(content, 'wb')
+    cmd_output('chmod', '+x', path)
+    assert main((str(path),)) == 0
+
+
+@skip_win32  # pragma: win32 no cover
+@pytest.mark.parametrize(
+    'content', (
+        b'#!/bin/bash\nhello world\n',
+        b'#!/usr/bin/env python3.10',
+        b'#!python',
+        '#!☃'.encode(),
+    ),
+)
+def test_not_executable_shebang(content, tmpdir, capsys):
+    path = tmpdir.join('path')
+    path.write(content, 'wb')
+    assert main((str(path),)) == 1
+    _, stderr = capsys.readouterr()
+    assert stderr.startswith(
+        f'{path}: has a shebang but is not marked executable!',
+    )
+
+
+@skip_win32  # pragma: win32 no cover
+@pytest.mark.parametrize(
+    'content', (
+        b'',
+        b' #!python\n',
+        b'\n#!python\n',
+        b'python\n',
+        '☃'.encode(),
+    ),
+)
+def test_not_executable_no_shebang(content, tmpdir, capsys):
+    path = tmpdir.join('path')
+    path.write(content, 'wb')
+    assert main((str(path),)) == 0
 
 
 def test_check_git_filemode_passing(tmpdir):

--- a/tests/check_shebang_scripts_are_executable_test.py
+++ b/tests/check_shebang_scripts_are_executable_test.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from pre_commit_hooks.check_shebang_scripts_are_executable import \
@@ -83,7 +81,5 @@ def test_git_executable_shebang(temp_git_dir, content, mode, expected):
         cmd_output('chmod', mode, str(path))
         cmd_output('git', 'update-index', f'--chmod={mode}', str(path))
 
-        # simulate how identify chooses that something is executable
-        filenames = [path for path in [str(path)] if os.access(path, os.X_OK)]
-
-        assert main(filenames) == expected
+        files = (str(path),)
+        assert main(files) == expected


### PR DESCRIPTION
The `check-shebang-scripts-are-executable` hook already avoided false negatives in a Git repository by looking up the Git file mode rather than relying on the file mode in the file system. Git already automatically probes the file system for executable bit support. Use the file mode in the file system when we are not in a Git clone or it is trusted by Git according to its `core.fileMode` config variable.

Also, fix previously asymptomatic copy/paste bug in `check_shebang_scripts_are_executable_test.test_git_executable_shebang` exposed by the other commit. This test manually filtered executable files out before calling `check_shebang_scripts_are_executable`. This makes sense in the test it was copied from, `check_executables_have_shebangs.test_git_executable_shebang`, because the `check-executables-have-shebangs` hook only runs on executable files. However, `check-shebang-scripts-are-executable` correctly runs on all text files, so the test shouldn't filter executable files out. The test still passed because when `git ls-files` is passed no files in particular, it
lists all files in the Git repository that satisfy the given filters.

Closes #749.