### PR TITLE
Update eof fixer

### DIFF
--- a/pre_commit_hooks/end_of_file_fixer.py
+++ b/pre_commit_hooks/end_of_file_fixer.py
@@ -62,7 +62,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         with open(filename, 'rb+') as file_obj:
             ret_for_file = fix_file(file_obj)
             if ret_for_file:
-                print(f'Fixing {filename}')
+                print(f'Fixed {filename}')
             retv |= ret_for_file
 
     return retv

--- a/pre_commit_hooks/end_of_file_fixer.py
+++ b/pre_commit_hooks/end_of_file_fixer.py
@@ -13,9 +13,10 @@ def fix_file(file_obj: IO[bytes]) -> int:
         file_obj.seek(-1, os.SEEK_END)
     except OSError:
         return 0
+
     last_character = file_obj.read(1)
-    # last_character will be '' for an empty file
-    if last_character not in {b'\n', b'\r'} and last_character != b'':
+
+    if last_character not in {b'\n', b'\r'}:
         # Needs this seek for windows, otherwise IOError
         file_obj.seek(0, os.SEEK_END)
         file_obj.write(b'\n')


### PR DESCRIPTION
This updates end_of_file_fixer.py. The commit messages should be self-explanatory, but here are a few notes:

For https://github.com/pre-commit/pre-commit-hooks/commit/67b1980f3e7396223928cd9a1dd7469f5915f28d, unless the comment on lines 10-11 are wrong, and I missed something in testing, there is no need to test for an empty file. https://github.com/pre-commit/pre-commit-hooks/blob/8f6152921e65fe1a82bc475cafb721bd525ba5df/pre_commit_hooks/end_of_file_fixer.py#L14 (`except OSError`) already takes care of empty files

For https://github.com/pre-commit/pre-commit-hooks/commit/36df47b046eee6af0816d6f366eaa5ef718006e6, I thought it made for sense to say "Fixed", rather than "Fixing", given that the file is already fixed by the time we print the message