### PR TITLE
Use tomli and tomllib instead of toml

### DIFF
--- a/pre_commit_hooks/check_toml.py
+++ b/pre_commit_hooks/check_toml.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from typing import Sequence
 
-import toml
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    import tomllib
+else:  # pragma: <3.11 cover
+    import tomli as tomllib
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -14,8 +18,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     retval = 0
     for filename in args.filenames:
         try:
-            toml.load(filename)
-        except toml.TomlDecodeError as exc:
+            with open(filename, mode='rb') as fp:
+                tomllib.load(fp)
+        except tomllib.TOMLDecodeError as exc:
             print(f'{filename}: {exc}')
             retval = 1
     return retval

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 packages = find:
 install_requires =
     ruamel.yaml>=0.15
-    toml
+    tomli>=1.1.0;python_version<"3.11"
 python_requires = >=3.7
 
 [options.packages.find]


### PR DESCRIPTION
Closes #755.

Originally this switch was rejected because the hope was that `toml` would be updated at one point, see https://github.com/pre-commit/pre-commit-hooks/pull/608. However, the latest commit is from 1 November 2020 ([commits](https://github.com/uiri/toml/commits/master)) and `tomli` will be part of Python `3.11` so it seems like a good candidate to replace it.

Similar PRs have been used in other "mainstream" projects like https://github.com/python/mypy/pull/12305 and https://github.com/pytest-dev/pytest/pull/9741.