### PR TITLE
set stages for `check-added-large-files`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,7 @@
     description: prevents giant files from being committed.
     entry: check-added-large-files
     language: python
+    stages: [commit, push, manual]
 -   id: check-ast
     name: check python ast
     description: simply checks whether the files parse as valid python.


### PR DESCRIPTION
looks like this was accidentally running on `commit-msg` hooks

resolves #777