### PR TITLE
Add parameter controlling whether lfs files are excluded from rule

### DIFF
--- a/pre_commit_hooks/check_added_large_files.py
+++ b/pre_commit_hooks/check_added_large_files.py
@@ -41,7 +41,7 @@ def find_large_added_files(
     # us about
     retv = 0
     filenames_filtered = set(filenames)
-    
+
     if allow_in_lfs:
         filter_lfs_files(filenames_filtered)
 

--- a/pre_commit_hooks/check_added_large_files.py
+++ b/pre_commit_hooks/check_added_large_files.py
@@ -33,6 +33,7 @@ def filter_lfs_files(filenames: set[str]) -> None:  # pragma: no cover (lfs)
 def find_large_added_files(
         filenames: Sequence[str],
         maxkb: int,
+        allow_in_lfs: bool,
         *,
         enforce_all: bool = False,
 ) -> int:
@@ -40,7 +41,9 @@ def find_large_added_files(
     # us about
     retv = 0
     filenames_filtered = set(filenames)
-    filter_lfs_files(filenames_filtered)
+    
+    if allow_in_lfs:
+        filter_lfs_files(filenames_filtered)
 
     if not enforce_all:
         filenames_filtered &= added_files()
@@ -65,6 +68,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         help='Enforce all files are checked, not just staged files.',
     )
     parser.add_argument(
+        '--allow-in-lfs', type=bool, default=true,
+        help='Whether to allow large files if stored in git lfs',
+    )
+    parser.add_argument(
         '--maxkb', type=int, default=500,
         help='Maximum allowable KB for added files',
     )
@@ -73,6 +80,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     return find_large_added_files(
         args.filenames,
         args.maxkb,
+        args.allow_in_lfs,
         enforce_all=args.enforce_all,
     )
 

--- a/pre_commit_hooks/check_added_large_files.py
+++ b/pre_commit_hooks/check_added_large_files.py
@@ -33,8 +33,8 @@ def filter_lfs_files(filenames: set[str]) -> None:  # pragma: no cover (lfs)
 def find_large_added_files(
         filenames: Sequence[str],
         maxkb: int,
-        allow_in_lfs: bool,
         *,
+        allow_in_lfs: bool = True,
         enforce_all: bool = False,
 ) -> int:
     # Find all added files that are also in the list of files pre-commit tells
@@ -80,7 +80,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     return find_large_added_files(
         args.filenames,
         args.maxkb,
-        args.allow_in_lfs,
+        allow_in_lfs=args.allow_in_lfs,
         enforce_all=args.enforce_all,
     )
 

--- a/pre_commit_hooks/check_added_large_files.py
+++ b/pre_commit_hooks/check_added_large_files.py
@@ -68,7 +68,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         help='Enforce all files are checked, not just staged files.',
     )
     parser.add_argument(
-        '--allow-in-lfs', type=bool, default=true,
+        '--allow-in-lfs', type=bool, default=True,
         help='Whether to allow large files if stored in git lfs',
     )
     parser.add_argument(

--- a/tests/check_added_large_files_test.py
+++ b/tests/check_added_large_files_test.py
@@ -96,6 +96,16 @@ def test_allows_gitlfs(temp_git_dir):  # pragma: no cover
         # Should succeed
         assert main(('--maxkb', '9', 'f.py')) == 0
 
+@xfailif_no_gitlfs
+def test_disallows_gitlfs_when_specified(temp_git_dir):  # pragma: no cover
+    with temp_git_dir.as_cwd():
+        cmd_output('git', 'lfs', 'install', '--local')
+        temp_git_dir.join('f.py').write('a' * 10000)
+        cmd_output('git', 'lfs', 'track', 'f.py')
+        cmd_output('git', 'add', '--', '.')
+        # Should reject file
+        assert main(('--maxkb', '9', '--allow-in-lfs', 'false', 'f.py')) == 1
+
 
 @xfailif_no_gitlfs
 def test_moves_with_gitlfs(temp_git_dir):  # pragma: no cover

--- a/tests/check_added_large_files_test.py
+++ b/tests/check_added_large_files_test.py
@@ -105,7 +105,7 @@ def test_disallows_gitlfs_when_specified(temp_git_dir):  # pragma: no cover
         cmd_output('git', 'lfs', 'track', 'f.py')
         cmd_output('git', 'add', '--', '.')
         # Should reject file
-        assert main(('--maxkb', '9', '--allow-in-lfs', 'false', 'f.py')) == 1
+        assert main(('--maxkb', '9', '--allow-in-lfs', 'False', 'f.py')) == 1
 
 
 @xfailif_no_gitlfs

--- a/tests/check_added_large_files_test.py
+++ b/tests/check_added_large_files_test.py
@@ -96,6 +96,7 @@ def test_allows_gitlfs(temp_git_dir):  # pragma: no cover
         # Should succeed
         assert main(('--maxkb', '9', 'f.py')) == 0
 
+
 @xfailif_no_gitlfs
 def test_disallows_gitlfs_when_specified(temp_git_dir):  # pragma: no cover
     with temp_git_dir.as_cwd():


### PR DESCRIPTION
Add `—allow-in-lfs=$BOOL` parameter to `check_added_large_files` to enable preventing large files from being stored — even if git lfs is available.

The parameter defaults to `true`. This maintains the current behavior of permitting large files as long as they are in lfs.