### PR TITLE
`name-tests-test`: Search tests in both `tests` and `test`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -167,7 +167,7 @@
     description: verifies that test files are named correctly.
     entry: name-tests-test
     language: python
-    files: (^|/)tests/.+\.py$
+    files: (^|/)test(s)?/.+\.py$
 -   id: no-commit-to-branch
     name: "don't commit to branch"
     entry: no-commit-to-branch


### PR DESCRIPTION
This makes the `s` in `tests` optional to allow both `tests` and `test` for placing the unit tests