### PR TITLE
Forbid the combination of unique and ignore case options in file_contents_sorter.py

### DIFF
--- a/pre_commit_hooks/file_contents_sorter.py
+++ b/pre_commit_hooks/file_contents_sorter.py
@@ -49,25 +49,25 @@ def sort_file_contents(
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(exit_on_error=False)
     parser.add_argument('filenames', nargs='+', help='Files to sort')
-    parser.add_argument(
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
         '--ignore-case',
         action='store_const',
         const=bytes.lower,
         default=None,
         help='fold lower case to upper case characters',
     )
-    parser.add_argument(
+    group.add_argument(
         '--unique',
         action='store_true',
         help='ensure each line is unique',
     )
-    args = parser.parse_args(argv)
-
-    if args.ignore_case and args.unique:
-        print('ERROR: usage of --unique and --ignore-case is unsupported. \
-        Please update your configuration.')
+    try:
+        args = parser.parse_args(argv)
+    except argparse.ArgumentError as e:
+        print(f'{e}')
         return FAIL
 
     retv = PASS

--- a/pre_commit_hooks/file_contents_sorter.py
+++ b/pre_commit_hooks/file_contents_sorter.py
@@ -65,6 +65,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.ignore_case and args.unique:
+        print('ERROR: usage of --unique and --ignore-case is unsupported. \
+        Please update your configuration.')
+        return FAIL
+
     retv = PASS
 
     for arg in args.filenames:

--- a/tests/file_contents_sorter_test.py
+++ b/tests/file_contents_sorter_test.py
@@ -68,12 +68,6 @@ from pre_commit_hooks.file_contents_sorter import PASS
         (
             b'fee\nFie\nFoe\nfum\n',
             ['--unique', '--ignore-case'],
-            PASS,
-            b'fee\nFie\nFoe\nfum\n',
-        ),
-        (
-            b'fee\nfee\nFie\nFoe\nfum\n',
-            ['--unique', '--ignore-case'],
             FAIL,
             b'fee\nFie\nFoe\nfum\n',
         ),


### PR DESCRIPTION
Example output when both options are specified:

```
usage: file_contents_sorter.py [-h] [--ignore-case | --unique] filenames [filenames ...]
file_contents_sorter.py: error: argument --unique: not allowed with argument --ignore-case
```

Closes #794.