### PR TITLE
Work around ruamel parser error

### DIFF
--- a/pre_commit_hooks/check_yaml.py
+++ b/pre_commit_hooks/check_yaml.py
@@ -8,7 +8,7 @@ from typing import Sequence
 
 import ruamel.yaml
 
-yaml = ruamel.yaml.YAML(typ='safe')
+yaml = ruamel.yaml.YAML(typ='safe', pure=True)
 
 
 def _exhaust(gen: Generator[str, None, None]) -> None:


### PR DESCRIPTION
This bug made it impossible to check all pnpm-lock.yaml files, if those contained local package tarballs.

I checked this on my production pnpm-lock.yaml file which was how I found the bug; it works fine now, along with some other random YAML files.

Resolves #827