### PR TITLE
yaml: add new option to ignore "!ansible" tags

### DIFF
--- a/pre_commit_hooks/check_yaml.py
+++ b/pre_commit_hooks/check_yaml.py
@@ -65,15 +65,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     load_fn = LOAD_FNS[Key(multi=args.multi, unsafe=args.unsafe)]
 
     if args.ignore_ansible_vault:
-        def ignore_ansible_vault(loader: ruamel.yaml.Loader,
-                                 node: ruamel.yaml.Node) -> Any:
+        def ignore_ansible_vault(
+            loader: ruamel.yaml.Loader,
+            node: ruamel.yaml.Node,
+        ) -> Any:
             if node.value.startswith('!vault'):
                 node.value = node.value[1:]
             return loader.construct_yaml_str(node)
 
-        ruamel.yaml.add_constructor(u'!vault',
-                                    ignore_ansible_vault,
-                                    constructor=ruamel.yaml.SafeConstructor)
+        ruamel.yaml.add_constructor(
+            '!vault',
+            ignore_ansible_vault,
+            constructor=ruamel.yaml.SafeConstructor,
+        )
 
     retval = 0
     for filename in args.filenames:

--- a/tests/check_yaml_test.py
+++ b/tests/check_yaml_test.py
@@ -51,3 +51,22 @@ def test_main_unsafe_still_fails_on_syntax_errors(tmpdir):
     f = tmpdir.join('test.yaml')
     f.write('[')
     assert main(('--unsafe', str(f)))
+
+
+def test_main_ignore_ansible_vault(tmpdir):
+    f = tmpdir.join('test.yaml')
+    f.write(
+        'some_foo: !vault |\n'
+        '    $ANSIBLE_VAULT;1.1;AES256\n'
+        '    deadbeefdeadbeefdeadbeef\n',
+    )
+    # should fail "safe" check
+    assert main((str(f),))
+    # should pass when we allow unsafe documents
+    assert not main(('--ignore-ansible-vault', str(f)))
+
+
+def test_main_ignore_ansible_vault_still_fails_on_syntax_errors(tmpdir):
+    f = tmpdir.join('test.yaml')
+    f.write('[')
+    assert main(('--ignore-ansible-vault', str(f)))


### PR DESCRIPTION
This new option for the yaml checker modify ruamel to remove the "!" from the "!vault" tag if it is found.
Removing that part allows the file to be parsed correctly, so other errors could be found.

fixes: #273