### PR TITLE
feat: add whitelist support for detect-private-key hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ The following arguments are available:
 #### `detect-private-key`
 Checks for the existence of private keys.
 
+The following arguments are available:
+- `--whitelist` - the filename with with the files (relative path) to whitelist. For example:
+
+  ```yaml
+  - id: detect-private-key
+    args: [--whitelist=.detect-private-key.whitelist]
+  ```
+
 #### `double-quote-string-fixer`
 This hook replaces double quoted strings with single quoted strings.
 

--- a/pre_commit_hooks/detect_private_key.py
+++ b/pre_commit_hooks/detect_private_key.py
@@ -20,14 +20,24 @@ BLACKLIST = [
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to check')
+    parser.add_argument(
+        '--whitelist',
+        help='The filename with with the files (relative path) to whitelist',
+    )
     args = parser.parse_args(argv)
 
     private_key_files = []
+    whitelisted_files = ''
+
+    if args.whitelist:
+        with open(args.whitelist) as f:
+            whitelisted_files = f.read()
 
     for filename in args.filenames:
         with open(filename, 'rb') as f:
             content = f.read()
-            if any(line in content for line in BLACKLIST):
+            if any(line in content for line in BLACKLIST) \
+                    and filename not in whitelisted_files:
                 private_key_files.append(filename)
 
     if private_key_files:


### PR DESCRIPTION
The motivation for this PR is to add an opinion to whitelist files during the execution of the `detect-private-key` hook. For the following content the `detect-private-key` hook return the exit code `1`, which is a false positive:

```yaml
extraTls: []
  ## @param ingress.secrets Custom TLS certificates as secrets
  ## NOTE: 'key' and 'certificate' are expected in PEM format
  ## NOTE: 'name' should line up with a 'secretName' set further up
  ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
  ## It is also possible to create and manage the certificates outside of this helm chart
  ## Please see README.md for more information
  ## e.g:
  ## secrets:
  ##   - name: rabbitmq.local-tls
  ##     key: |-
  ##       -----BEGIN RSA PRIVATE KEY-----
  ##       ...
  ##       -----END RSA PRIVATE KEY-----
  ##     certificate: |-
  ##       -----BEGIN CERTIFICATE-----
  ##       ...
  ##       -----END CERTIFICATE-----
```

This PR defines a new argument for the detect-private-key` hook, e.g.:

```yaml
- id: detect-private-key
    args: [--whitelist=.detect-private-key.whitelist]
```

Then the `.detect-private-key.whitelist` file can have the following content:
```
modules/kubernetes-rabbitmq-cluster/templates/values-rabbitmq-production.yaml.tpl
```