### PR TITLE
Stop pkg_resources from being added as well

### DIFF
--- a/pre_commit_hooks/requirements_txt_fixer.py
+++ b/pre_commit_hooks/requirements_txt_fixer.py
@@ -115,7 +115,10 @@ def fix_requirements(f: IO[bytes]) -> int:
     # which is automatically added by broken pip package under Debian
     requirements = [
         req for req in requirements
-        if req.value != b'pkg-resources==0.0.0\n'
+        if req.value not in [
+            b'pkg-resources==0.0.0\n',
+            b'pkg_resources==0.0.0\n',
+        ]
     ]
 
     # sort the requirements and remove duplicates

--- a/tests/requirements_txt_fixer_test.py
+++ b/tests/requirements_txt_fixer_test.py
@@ -82,6 +82,8 @@ from pre_commit_hooks.requirements_txt_fixer import Requirement
         ),
         (b'bar\npkg-resources==0.0.0\nfoo\n', FAIL, b'bar\nfoo\n'),
         (b'foo\npkg-resources==0.0.0\nbar\n', FAIL, b'bar\nfoo\n'),
+        (b'bar\npkg_resources==0.0.0\nfoo\n', FAIL, b'bar\nfoo\n'),
+        (b'foo\npkg_resources==0.0.0\nbar\n', FAIL, b'bar\nfoo\n'),
         (
             b'git+ssh://git_url@tag#egg=ocflib\nDjango\nijk\n',
             FAIL,


### PR DESCRIPTION
This package with an underscore instead of a dash seems to be new behavior (at least on Ubuntu 20.04 with Python 3.8

Fixes #1030