### PR TITLE
Preserve float formatting when pretty formatting

### DIFF
--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -42,17 +42,17 @@ class FloatPreservingEncoder(json.JSONEncoder):
         ):
 
             if o != o:
-                text = "NaN"
+                text = 'NaN'
             elif o == _inf:
-                text = "Infinity"
+                text = 'Infinity'
             elif o == _neginf:
-                text = "-Infinity"
+                text = '-Infinity'
             else:
                 return _repr(o)
 
             if not allow_nan:
                 raise ValueError(
-                    "Out of range float values are not JSON compliant: " + repr(o)
+                    'Out of range float values are not JSON compliant: ' + repr(o),
                 )
 
             return text

--- a/testing/resources/float_formatting.json
+++ b/testing/resources/float_formatting.json
@@ -1,0 +1,12 @@
+{
+  "exponential": 1e9,
+  "high_precision": 4.4257052820783003,
+  "list": [
+    1e9,
+    4.4257052820783003
+  ],
+  "mapping": {
+    "exponential": 1e9,
+    "high_precision": 4.4257052820783003
+  }
+}

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -23,6 +23,7 @@ def test_parse_num_to_int():
         ('unsorted_pretty_formatted_json.json', 1),
         ('non_ascii_pretty_formatted_json.json', 1),
         ('pretty_formatted_json.json', 0),
+        ('float_formatting.json', 0),
     ),
 )
 def test_main(filename, expected_retval):


### PR DESCRIPTION
Prevents high-precision and exponential-formatted floats from being modified when using the `pretty-format-json` hook. Closes #780