### PR TITLE
end_of_file_fixer: write platform native line endings

### DIFF
--- a/pre_commit_hooks/end_of_file_fixer.py
+++ b/pre_commit_hooks/end_of_file_fixer.py
@@ -7,6 +7,7 @@ from typing import Sequence
 
 platform_eol = os.linesep.encode('ascii')
 
+
 def fix_file(file_obj: IO[bytes]) -> int:
     # Test for newline at end of file
     # Empty files will throw IOError here

--- a/pre_commit_hooks/end_of_file_fixer.py
+++ b/pre_commit_hooks/end_of_file_fixer.py
@@ -5,6 +5,7 @@ import os
 from typing import IO
 from typing import Sequence
 
+platform_eol = os.linesep.encode('ascii')
 
 def fix_file(file_obj: IO[bytes]) -> int:
     # Test for newline at end of file
@@ -18,7 +19,7 @@ def fix_file(file_obj: IO[bytes]) -> int:
     if last_character not in {b'\n', b'\r'} and last_character != b'':
         # Needs this seek for windows, otherwise IOError
         file_obj.seek(0, os.SEEK_END)
-        file_obj.write(b'\n')
+        file_obj.write(platform_eol)
         return 1
 
     while last_character in {b'\n', b'\r'}:

--- a/tests/end_of_file_fixer_test.py
+++ b/tests/end_of_file_fixer_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import os
 
 import pytest
 
@@ -9,14 +10,15 @@ from pre_commit_hooks.end_of_file_fixer import main
 
 
 # Input, expected return value, expected output
+platform_eol = os.linesep.encode('ascii')
 TESTS = (
     (b'foo\n', 0, b'foo\n'),
     (b'', 0, b''),
     (b'\n\n', 1, b''),
     (b'\n\n\n\n', 1, b''),
-    (b'foo', 1, b'foo\n'),
+    (b'foo', 1, b'foo' + platform_eol),
     (b'foo\n\n\n', 1, b'foo\n'),
-    (b'\xe2\x98\x83', 1, b'\xe2\x98\x83\n'),
+    (b'\xe2\x98\x83', 1, b'\xe2\x98\x83' + platform_eol),
     (b'foo\r\n', 0, b'foo\r\n'),
     (b'foo\r\n\r\n\r\n', 1, b'foo\r\n'),
     (b'foo\r', 0, b'foo\r'),


### PR DESCRIPTION
The most common setup for git is to use platform-native line endings in checkout (`core.autocrlf` set to `true`). So the eol file fixer should write native line endings.