### PR TITLE
end_of_file_fixer: detect line ending

### DIFF
--- a/tests/end_of_file_fixer_test.py
+++ b/tests/end_of_file_fixer_test.py
@@ -21,6 +21,9 @@ TESTS = (
     (b'foo\r\n\r\n\r\n', 1, b'foo\r\n'),
     (b'foo\r', 0, b'foo\r'),
     (b'foo\r\r\r\r', 1, b'foo\r'),
+    (b'foo\r\nbar', 1, b'foo\r\nbar\r\n'),
+    (b'foo\nbar', 1, b'foo\nbar\n'),
+    (b'foo\rbar', 1, b'foo\rbar\r'),
 )
 
 


### PR DESCRIPTION
Instead of writing \n we try to detect the line ending used in the file. We use the first line ending sequence we find.