### PR TITLE
Add option to reject requirements files if any packages are missing a version string

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,9 @@ the following commandline options:
   - `--top-keys comma,separated,keys` - Keys to keep at the top of mappings.
 
 #### `requirements-txt-fixer`
-Sorts entries in requirements.txt and constraints.txt and removes incorrect entry for `pkg-resources==0.0.0`
+Sorts entries in requirements.txt and constraints.txt and removes incorrect entry for `pkg-resources==0.0.0`. Optionally flags packages that are missing
+a version string. You can configure this with the following commandline options:
+  - `--require_version` - Fail if any package is missing a version string.
 
 #### `sort-simple-yaml`
 Sorts simple YAML files which consist only of top-level

--- a/pre_commit_hooks/requirements_txt_fixer.py
+++ b/pre_commit_hooks/requirements_txt_fixer.py
@@ -12,7 +12,7 @@ FAIL = 1
 
 class Requirement:
     UNTIL_COMPARISON = re.compile(b'={2,3}|!=|~=|>=?|<=?')
-    VERSION_MATCHER = re.compile(b'(?:={2,3}|!=|~=|>=?|<=?|@)\s*(?P<version>[A-Za-z0-9./:]+)$')
+    VERSION_MATCHER = re.compile(br'(?:={2,3}|!=|~=|>=?|<=?|@)\s*(?P<version>[A-Za-z0-9./:]+)$')  # noqa: E501
     UNTIL_SEP = re.compile(rb'[^;\s]+')
 
     def __init__(self) -> None:
@@ -41,7 +41,9 @@ class Requirement:
     def has_version(self) -> bool:
         return self.extract_version() is not None
 
-    def extract_version(self):
+    def extract_version(self) -> str | None:
+        if not self.value:
+            return None
         matches = self.VERSION_MATCHER.search(self.value)
         if matches:
             self.version = matches.groups()[0].decode()
@@ -145,7 +147,7 @@ def fix_requirements(f: IO[bytes], require_version: bool = False) -> int:
     outcome = PASS
 
     if len(missing_versions) > 0:
-        print("Missing versions in:", ", ".join(missing_versions))
+        print('Missing versions in:', ', '.join(missing_versions))
         outcome = FAIL
 
     if before_string != after_string:
@@ -160,11 +162,12 @@ def fix_requirements(f: IO[bytes], require_version: bool = False) -> int:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
-    parser.add_argument('-r', '--require_version',
+    parser.add_argument(
+        '-r', '--require_version',
         required=False,
-        help='Use this to require each requirement to include a version number',
+        help='Each requirement must include a version number',
         action='store_true',
-        default=False
+        default=False,
     )
     args = parser.parse_args(argv)
 

--- a/tests/requirements_txt_fixer_test.py
+++ b/tests/requirements_txt_fixer_test.py
@@ -122,9 +122,18 @@ def test_requirement_object():
     requirement_bar = Requirement()
     requirement_bar.value = b'bar'
 
+    requirement_baz = Requirement()
+    requirement_baz.value = b'baz>=1.2.3'
+
     # This may look redundant, but we need to test both foo.__lt__(bar) and
     # bar.__lt__(foo)
     assert requirement_foo > top_of_file
     assert top_of_file < requirement_foo
     assert requirement_foo > requirement_bar
     assert requirement_bar < requirement_foo
+
+    # Test the version extraction code
+    assert not requirement_foo.has_version()
+    assert not requirement_bar.has_version()
+    assert requirement_baz.has_version()
+    assert requirement_baz.version == '1.2.3'


### PR DESCRIPTION
Rationale: some teams require specifying a version for every package listed in their requirements files, for quasi-reproducible builds that will prevent new versions of pip packages breaking their code.

This option is off by default, to preserve backward compatibility.