### PR TITLE
add __import__("pdb") handling

### DIFF
--- a/pre_commit_hooks/debug_statement_hook.py
+++ b/pre_commit_hooks/debug_statement_hook.py
@@ -8,15 +8,15 @@ from typing import Sequence
 
 
 DEBUG_STATEMENTS = {
-    "ipdb",
-    "pdb",
-    "pdbr",
-    "pudb",
-    "pydevd_pycharm",
-    "q",
-    "rdb",
-    "rpdb",
-    "wdb",
+    'ipdb',
+    'pdb',
+    'pdbr',
+    'pudb',
+    'pydevd_pycharm',
+    'q',
+    'rdb',
+    'rpdb',
+    'wdb',
 }
 
 
@@ -34,7 +34,7 @@ class DebugStatementParser(ast.NodeVisitor):
     def visit_Import(self, node: ast.Import) -> None:
         for name in node.names:
             if name.name in DEBUG_STATEMENTS:
-                st = Debug(node.lineno, node.col_offset, name.name, "imported")
+                st = Debug(node.lineno, node.col_offset, name.name, 'imported')
                 self.breakpoints.append(st)
 
     def visit_Expr(self, node: ast.Expr) -> None:
@@ -43,34 +43,34 @@ class DebugStatementParser(ast.NodeVisitor):
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         if node.module in DEBUG_STATEMENTS:
-            st = Debug(node.lineno, node.col_offset, node.module, "imported")
+            st = Debug(node.lineno, node.col_offset, node.module, 'imported')
             self.breakpoints.append(st)
 
     def visit_Call(self, node: ast.Call) -> None:
         """python3.7+ breakpoint() and __import__"""
         if isinstance(node.func, ast.Name):
-            if node.func.id == "breakpoint":
-                st = Debug(node.lineno, node.col_offset, node.func.id, "called")
+            if node.func.id == 'breakpoint':
+                st = Debug(node.lineno, node.col_offset, node.func.id, 'called')
                 self.breakpoints.append(st)
             if (
-                    node.func.id == "__import__"
-                    and isinstance(node.args[0], ast.Constant)
-                    and len(node.args) > 0
-                    and node.args[0].value in DEBUG_STATEMENTS
+                    node.func.id == '__import__' and
+                    isinstance(node.args[0], ast.Constant) and
+                    len(node.args) > 0 and
+                    node.args[0].value in DEBUG_STATEMENTS
             ):
-                st = Debug(node.lineno, node.col_offset, node.args[0].value, "imported")
+                st = Debug(node.lineno, node.col_offset, node.args[0].value, 'imported')
                 self.breakpoints.append(st)
         self.generic_visit(node)
 
 
 def check_file(filename: str) -> int:
     try:
-        with open(filename, "rb") as f:
+        with open(filename, 'rb') as f:
             ast_obj = ast.parse(f.read(), filename=filename)
     except SyntaxError:
-        print(f"{filename} - Could not parse ast")
+        print(f'{filename} - Could not parse ast')
         print()
-        print("\t" + traceback.format_exc().replace("\n", "\n\t"))
+        print('\t' + traceback.format_exc().replace('\n', '\n\t'))
         print()
         return 1
 
@@ -78,14 +78,14 @@ def check_file(filename: str) -> int:
     visitor.visit(ast_obj)
 
     for bp in visitor.breakpoints:
-        print(f"{filename}:{bp.line}:{bp.col}: {bp.name} {bp.reason}")
+        print(f'{filename}:{bp.line}:{bp.col}: {bp.name} {bp.reason}')
 
     return int(bool(visitor.breakpoints))
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("filenames", nargs="*", help="Filenames to run")
+    parser.add_argument('filenames', nargs='*', help='Filenames to run')
     args = parser.parse_args(argv)
 
     retv = 0
@@ -94,5 +94,5 @@ def main(argv: Sequence[str] | None = None) -> int:
     return retv
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     raise SystemExit(main())

--- a/pre_commit_hooks/debug_statement_hook.py
+++ b/pre_commit_hooks/debug_statement_hook.py
@@ -8,15 +8,15 @@ from typing import Sequence
 
 
 DEBUG_STATEMENTS = {
-    'ipdb',
-    'pdb',
-    'pdbr',
-    'pudb',
-    'pydevd_pycharm',
-    'q',
-    'rdb',
-    'rpdb',
-    'wdb',
+    "ipdb",
+    "pdb",
+    "pdbr",
+    "pudb",
+    "pydevd_pycharm",
+    "q",
+    "rdb",
+    "rpdb",
+    "wdb",
 }
 
 
@@ -34,30 +34,43 @@ class DebugStatementParser(ast.NodeVisitor):
     def visit_Import(self, node: ast.Import) -> None:
         for name in node.names:
             if name.name in DEBUG_STATEMENTS:
-                st = Debug(node.lineno, node.col_offset, name.name, 'imported')
+                st = Debug(node.lineno, node.col_offset, name.name, "imported")
                 self.breakpoints.append(st)
+
+    def visit_Expr(self, node: ast.Expr) -> None:
+        if isinstance(node.value, ast.Call):
+            self.visit(node.value)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         if node.module in DEBUG_STATEMENTS:
-            st = Debug(node.lineno, node.col_offset, node.module, 'imported')
+            st = Debug(node.lineno, node.col_offset, node.module, "imported")
             self.breakpoints.append(st)
 
     def visit_Call(self, node: ast.Call) -> None:
-        """python3.7+ breakpoint()"""
-        if isinstance(node.func, ast.Name) and node.func.id == 'breakpoint':
-            st = Debug(node.lineno, node.col_offset, node.func.id, 'called')
-            self.breakpoints.append(st)
+        """python3.7+ breakpoint() and __import__"""
+        if isinstance(node.func, ast.Name):
+            if node.func.id == "breakpoint":
+                st = Debug(node.lineno, node.col_offset, node.func.id, "called")
+                self.breakpoints.append(st)
+            if (
+                    node.func.id == "__import__"
+                    and isinstance(node.args[0], ast.Constant)
+                    and len(node.args) > 0
+                    and node.args[0].value in DEBUG_STATEMENTS
+            ):
+                st = Debug(node.lineno, node.col_offset, node.args[0].value, "imported")
+                self.breakpoints.append(st)
         self.generic_visit(node)
 
 
 def check_file(filename: str) -> int:
     try:
-        with open(filename, 'rb') as f:
+        with open(filename, "rb") as f:
             ast_obj = ast.parse(f.read(), filename=filename)
     except SyntaxError:
-        print(f'{filename} - Could not parse ast')
+        print(f"{filename} - Could not parse ast")
         print()
-        print('\t' + traceback.format_exc().replace('\n', '\n\t'))
+        print("\t" + traceback.format_exc().replace("\n", "\n\t"))
         print()
         return 1
 
@@ -65,14 +78,14 @@ def check_file(filename: str) -> int:
     visitor.visit(ast_obj)
 
     for bp in visitor.breakpoints:
-        print(f'{filename}:{bp.line}:{bp.col}: {bp.name} {bp.reason}')
+        print(f"{filename}:{bp.line}:{bp.col}: {bp.name} {bp.reason}")
 
     return int(bool(visitor.breakpoints))
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument('filenames', nargs='*', help='Filenames to run')
+    parser.add_argument("filenames", nargs="*", help="Filenames to run")
     args = parser.parse_args(argv)
 
     retv = 0
@@ -81,5 +94,5 @@ def main(argv: Sequence[str] | None = None) -> int:
     return retv
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/tests/debug_statement_hook_test.py
+++ b/tests/debug_statement_hook_test.py
@@ -10,31 +10,44 @@ from testing.util import get_resource_path
 
 def test_no_breakpoints():
     visitor = DebugStatementParser()
-    visitor.visit(ast.parse('import os\nfrom foo import bar\n'))
+    visitor.visit(ast.parse("import os\nfrom foo import bar\n"))
     assert visitor.breakpoints == []
 
 
 def test_finds_debug_import_attribute_access():
     visitor = DebugStatementParser()
-    visitor.visit(ast.parse('import ipdb; ipdb.set_trace()'))
-    assert visitor.breakpoints == [Debug(1, 0, 'ipdb', 'imported')]
+    visitor.visit(ast.parse("import ipdb; ipdb.set_trace()"))
+    assert visitor.breakpoints == [Debug(1, 0, "ipdb", "imported")]
 
 
 def test_finds_debug_import_from_import():
     visitor = DebugStatementParser()
-    visitor.visit(ast.parse('from pudb import set_trace; set_trace()'))
-    assert visitor.breakpoints == [Debug(1, 0, 'pudb', 'imported')]
+    visitor.visit(ast.parse("from pudb import set_trace; set_trace()"))
+    assert visitor.breakpoints == [Debug(1, 0, "pudb", "imported")]
+
+
+def test_finds_debug_import_from_dunder_import():
+    visitor = DebugStatementParser()
+    visitor.visit(ast.parse("__import__('pdb').set_trace()"))
+    assert visitor.breakpoints == [Debug(1, 0, "pdb", "imported")]
 
 
 def test_finds_breakpoint():
     visitor = DebugStatementParser()
-    visitor.visit(ast.parse('breakpoint()'))
-    assert visitor.breakpoints == [Debug(1, 0, 'breakpoint', 'called')]
+    visitor.visit(ast.parse("breakpoint()"))
+    assert visitor.breakpoints == [Debug(1, 0, "breakpoint", "called")]
 
 
 def test_returns_one_for_failing_file(tmpdir):
-    f_py = tmpdir.join('f.py')
-    f_py.write('def f():\n    import pdb; pdb.set_trace()')
+    f_py = tmpdir.join("f.py")
+    f_py.write("def f():\n    import pdb; pdb.set_trace()")
+    ret = main([str(f_py)])
+    assert ret == 1
+
+
+def test_returns_one_for_failing_file_inline_pdb(tmpdir):
+    f_py = tmpdir.join("f.py")
+    f_py.write('def f():\n    __import__("pdb").set_trace()')
     ret = main([str(f_py)])
     assert ret == 1
 
@@ -45,19 +58,19 @@ def test_returns_zero_for_passing_file():
 
 
 def test_syntaxerror_file():
-    ret = main([get_resource_path('cannot_parse_ast.notpy')])
+    ret = main([get_resource_path("cannot_parse_ast.notpy")])
     assert ret == 1
 
 
 def test_non_utf8_file(tmpdir):
-    f_py = tmpdir.join('f.py')
-    f_py.write_binary('# -*- coding: cp1252 -*-\nx = "€"\n'.encode('cp1252'))
+    f_py = tmpdir.join("f.py")
+    f_py.write_binary('# -*- coding: cp1252 -*-\nx = "€"\n'.encode("cp1252"))
     assert main((str(f_py),)) == 0
 
 
 def test_py37_breakpoint(tmpdir, capsys):
-    f_py = tmpdir.join('f.py')
-    f_py.write('def f():\n    breakpoint()\n')
+    f_py = tmpdir.join("f.py")
+    f_py.write("def f():\n    breakpoint()\n")
     assert main((str(f_py),)) == 1
     out, _ = capsys.readouterr()
-    assert out == f'{f_py}:2:4: breakpoint called\n'
+    assert out == f"{f_py}:2:4: breakpoint called\n"

--- a/tests/debug_statement_hook_test.py
+++ b/tests/debug_statement_hook_test.py
@@ -10,43 +10,43 @@ from testing.util import get_resource_path
 
 def test_no_breakpoints():
     visitor = DebugStatementParser()
-    visitor.visit(ast.parse("import os\nfrom foo import bar\n"))
+    visitor.visit(ast.parse('import os\nfrom foo import bar\n'))
     assert visitor.breakpoints == []
 
 
 def test_finds_debug_import_attribute_access():
     visitor = DebugStatementParser()
-    visitor.visit(ast.parse("import ipdb; ipdb.set_trace()"))
-    assert visitor.breakpoints == [Debug(1, 0, "ipdb", "imported")]
+    visitor.visit(ast.parse('import ipdb; ipdb.set_trace()'))
+    assert visitor.breakpoints == [Debug(1, 0, 'ipdb', 'imported')]
 
 
 def test_finds_debug_import_from_import():
     visitor = DebugStatementParser()
-    visitor.visit(ast.parse("from pudb import set_trace; set_trace()"))
-    assert visitor.breakpoints == [Debug(1, 0, "pudb", "imported")]
+    visitor.visit(ast.parse('from pudb import set_trace; set_trace()'))
+    assert visitor.breakpoints == [Debug(1, 0, 'pudb', 'imported')]
 
 
 def test_finds_debug_import_from_dunder_import():
     visitor = DebugStatementParser()
     visitor.visit(ast.parse("__import__('pdb').set_trace()"))
-    assert visitor.breakpoints == [Debug(1, 0, "pdb", "imported")]
+    assert visitor.breakpoints == [Debug(1, 0, 'pdb', 'imported')]
 
 
 def test_finds_breakpoint():
     visitor = DebugStatementParser()
-    visitor.visit(ast.parse("breakpoint()"))
-    assert visitor.breakpoints == [Debug(1, 0, "breakpoint", "called")]
+    visitor.visit(ast.parse('breakpoint()'))
+    assert visitor.breakpoints == [Debug(1, 0, 'breakpoint', 'called')]
 
 
 def test_returns_one_for_failing_file(tmpdir):
-    f_py = tmpdir.join("f.py")
-    f_py.write("def f():\n    import pdb; pdb.set_trace()")
+    f_py = tmpdir.join('f.py')
+    f_py.write('def f():\n    import pdb; pdb.set_trace()')
     ret = main([str(f_py)])
     assert ret == 1
 
 
 def test_returns_one_for_failing_file_inline_pdb(tmpdir):
-    f_py = tmpdir.join("f.py")
+    f_py = tmpdir.join('f.py')
     f_py.write('def f():\n    __import__("pdb").set_trace()')
     ret = main([str(f_py)])
     assert ret == 1
@@ -58,19 +58,19 @@ def test_returns_zero_for_passing_file():
 
 
 def test_syntaxerror_file():
-    ret = main([get_resource_path("cannot_parse_ast.notpy")])
+    ret = main([get_resource_path('cannot_parse_ast.notpy')])
     assert ret == 1
 
 
 def test_non_utf8_file(tmpdir):
-    f_py = tmpdir.join("f.py")
-    f_py.write_binary('# -*- coding: cp1252 -*-\nx = "€"\n'.encode("cp1252"))
+    f_py = tmpdir.join('f.py')
+    f_py.write_binary('# -*- coding: cp1252 -*-\nx = "€"\n'.encode('cp1252'))
     assert main((str(f_py),)) == 0
 
 
 def test_py37_breakpoint(tmpdir, capsys):
-    f_py = tmpdir.join("f.py")
-    f_py.write("def f():\n    breakpoint()\n")
+    f_py = tmpdir.join('f.py')
+    f_py.write('def f():\n    breakpoint()\n')
     assert main((str(f_py),)) == 1
     out, _ = capsys.readouterr()
-    assert out == f"{f_py}:2:4: breakpoint called\n"
+    assert out == f'{f_py}:2:4: breakpoint called\n'


### PR DESCRIPTION
Sometimes, we use the one liner `__import__('pdb').set_trace()` to set the breakpoints which was not supported.
This PR aims to handle this case, so that we can use the `debug_statement_hook` and catch this.