### PR TITLE
Exclude jupyter notebooks from the pretty-format-json check by default 

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -59,6 +59,7 @@
     entry: pretty-format-json
     language: python
     types: [json]
+    exclude_types: [jupyter]
 -   id: check-merge-conflict
     name: check for merge conflicts
     description: checks for files that contain merge conflict strings.


### PR DESCRIPTION
This PR proposes excluding Jupyter notebooks by default from the pretty-format-json hook.

A recent PR added jupyter notebooks (`.ipynb`) files as a `json` type, on the grounds that notebooks are stored as JSON files:
https://github.com/pre-commit/identify/pull/401

Whilst this makes sense for the `check-json` hook, it causes some problems with the `pretty-format-hook` as described in [this comment](https://github.com/pre-commit/identify/pull/401#issuecomment-1651690699). Jupyter notebooks are conventionally saved with an indent of 1, whereas the pretty-format-hook uses a default indent of 4.

A proposed solution is just to exclude jupyter notebooks from the pretty-format-hook by default, which I think is broadly consistent with previous behaviour before PR above was added.