### PR TITLE
Add bpdb to debug_statements_hook

### DIFF
--- a/pre_commit_hooks/debug_statement_hook.py
+++ b/pre_commit_hooks/debug_statement_hook.py
@@ -8,6 +8,7 @@ from typing import Sequence
 
 
 DEBUG_STATEMENTS = {
+    'bpdb',
     'ipdb',
     'pdb',
     'pdbr',


### PR DESCRIPTION
This patch adds the bpython debugger import `bpdb` to the debug_statements_hook.

Closes #941