### PR TITLE
Fix blank lines in file-contents-sorter plugin

### DIFF
--- a/pre_commit_hooks/file_contents_sorter.py
+++ b/pre_commit_hooks/file_contents_sorter.py
@@ -37,7 +37,10 @@ def sort_file_contents(
     after = sorted(lines, key=key)
 
     before_string = b''.join(before)
-    after_string = b'\n'.join(after) + b'\n'
+    after_string = b'\n'.join(after)
+
+    if after_string:
+        after_string += b'\n'
 
     if before_string == after_string:
         return PASS

--- a/tests/file_contents_sorter_test.py
+++ b/tests/file_contents_sorter_test.py
@@ -10,7 +10,9 @@ from pre_commit_hooks.file_contents_sorter import PASS
 @pytest.mark.parametrize(
     ('input_s', 'argv', 'expected_retval', 'output'),
     (
-        (b'', [], FAIL, b'\n'),
+        (b'', [], PASS, b''),
+        (b'\n', [], FAIL, b''),
+        (b'\n\n', [], FAIL, b''),
         (b'lonesome\n', [], PASS, b'lonesome\n'),
         (b'missing_newline', [], FAIL, b'missing_newline\n'),
         (b'newline\nmissing', [], FAIL, b'missing\nnewline\n'),


### PR DESCRIPTION
As stated in the documentation: `Note that this hook WILL remove blank lines`. Previously this hook would always add blank a blank line. 

With this fix, if the file is empty, a newline will not be added, and multiple blank lines in a file will be removed.

Fixes #935