### PR TITLE
for pretty-format-json add option: --empty-object-with-newline

### DIFF
--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 import re
-
+import sys
 from difflib import unified_diff
 from typing import Mapping
 from typing import Sequence
 
+
 def _insert_linebreaks(json_str) -> str:
     # (?P<spaces>\s*) seems to capture the \n. Hence, there is no need for it in the substitution string
-    return re.sub(r'\n(?P<spaces>\s*)(?P<json_key>.*): {}(?P<delim>,??)', '\n\g<spaces>\g<json_key>: {\n\g<spaces>}\g<delim>', json_str)
+    return re.sub(r'\n(?P<spaces>\s*)(?P<json_key>.*): {}(?P<delim>,??)', '\n\\g<spaces>\\g<json_key>: {\n\\g<spaces>}\\g<delim>', json_str)
+
 
 def _get_pretty_format(
         contents: str,
@@ -126,7 +127,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             pretty_contents = _get_pretty_format(
                 contents, args.indent, ensure_ascii=not args.no_ensure_ascii,
                 sort_keys=not args.no_sort_keys, top_keys=args.top_keys,
-                empty_object_with_newline=args.empty_object_with_newline
+                empty_object_with_newline=args.empty_object_with_newline,
             )
         except ValueError:
             print(
@@ -144,7 +145,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             else:
                 diff_output = get_diff(contents, pretty_contents, json_file)
                 sys.stdout.buffer.write(diff_output.encode())
-
 
     return status
 

--- a/testing/resources/empty_object_json_multiline.json
+++ b/testing/resources/empty_object_json_multiline.json
@@ -1,0 +1,17 @@
+{
+  "empty": {
+  },
+  "inhabited": {
+    "person": {
+      "name": "Roger",
+      "nested_empty_with_comma": {
+      },
+      "array": [
+        {
+          "nested_empty_in_array": {
+          }
+        }
+      ]
+    }
+  }
+}

--- a/testing/resources/empty_object_json_sameline.json
+++ b/testing/resources/empty_object_json_sameline.json
@@ -1,0 +1,14 @@
+{
+  "empty": {},
+  "inhabited": {
+    "person": {
+      "name": "Roger",
+      "nested_empty_with_comma": {},
+      "array": [
+        {
+          "nested_empty_in_array": {}
+        }
+      ]
+    }
+  }
+}

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import filecmp
 import os
 import shutil
 
 import pytest
-import filecmp
 
 from pre_commit_hooks.pretty_format_json import main
 from pre_commit_hooks.pretty_format_json import parse_num_to_int
@@ -142,13 +142,13 @@ def test_diffing_output(capsys):
 
 def test_empty_object_with_newline(tmpdir):
     # same line objects shoud trigger with --empty-object-with-newline switch
-    sameline = get_resource_path("empty_object_json_sameline.json")
-    ret = main(["--empty-object-with-newline", str(sameline)])
+    sameline = get_resource_path('empty_object_json_sameline.json')
+    ret = main(['--empty-object-with-newline', str(sameline)])
     assert ret == 1
 
-    multiline = get_resource_path("empty_object_json_multiline.json")
+    multiline = get_resource_path('empty_object_json_multiline.json')
     to_be_formatted_sameline = tmpdir.join(
-        "not_pretty_formatted_empty_object_json_sameline.json"
+        'not_pretty_formatted_empty_object_json_sameline.json',
     )
     shutil.copyfile(str(sameline), str(to_be_formatted_sameline))
 
@@ -158,12 +158,12 @@ def test_empty_object_with_newline(tmpdir):
 
     # now launch the autofix with empty object with newline support on that file
     ret = main(
-        ["--autofix", "--empty-object-with-newline", str(to_be_formatted_sameline)]
+        ['--autofix', '--empty-object-with-newline', str(to_be_formatted_sameline)],
     )
     # it should have formatted it and don't raise an error code
     assert ret == 0
 
     # file was formatted (shouldn't trigger linter with --empty-object-with-newline switch)
-    ret = main(["--empty-object-with-newline", str(to_be_formatted_sameline)])
+    ret = main(['--empty-object-with-newline', str(to_be_formatted_sameline)])
     assert ret == 0
     assert filecmp.cmp(to_be_formatted_sameline, multiline)


### PR DESCRIPTION
In Shopify theme development, there is a GitHub bot which pulls in changes in GitHub repos.
Sadly it formats .json files in a non standard way. Hence, every empty object get's a newline, which doesn't not conform to standard formatting. 
This creates then a new commit in the branch, which is pushed back into the origin repo. Which needs to be pulled to be able to push again. It's creating a cycle.

Hence, I created the formatting option _--empty-object-with-newline_ to conform to the Shopify .json formatting to prevent commit pollution.