### PR TITLE
Document newline behavior of `file-contents-sorter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Makes sure files end in a newline and only a newline.
 Sort the lines in specified files (defaults to alphabetical).
 You must provide the target [`files`](https://pre-commit.com/#config-files) as input.
 Note that this hook WILL remove blank lines and does NOT respect any comments.
+All newlines will be converted to line feeds (`\n`).
 
 The following arguments are available:
 - `--ignore-case` - fold lower case to upper case characters.


### PR DESCRIPTION
Let's document the behavior and suggest what to do for users of the hook.

Ref: #958, #959