### PR TITLE
[no_commit_to_branch] Add user friendly error message

### DIFF
--- a/pre_commit_hooks/no_commit_to_branch.py
+++ b/pre_commit_hooks/no_commit_to_branch.py
@@ -9,29 +9,37 @@ from pre_commit_hooks.util import CalledProcessError
 from pre_commit_hooks.util import cmd_output
 
 
-def is_on_branch(
-        protected: AbstractSet[str],
-        patterns: AbstractSet[str] = frozenset(),
-) -> bool:
+def get_current_branch() -> str | None:
     try:
         ref_name = cmd_output('git', 'symbolic-ref', 'HEAD')
     except CalledProcessError:
-        return False
+        return None
     chunks = ref_name.strip().split('/')
-    branch_name = '/'.join(chunks[2:])
-    return branch_name in protected or any(
-        re.match(p, branch_name) for p in patterns
+    return '/'.join(chunks[2:])
+
+
+def is_on_branch(
+    current_branch: str,
+    protected: AbstractSet[str],
+    patterns: AbstractSet[str] = frozenset(),
+) -> bool:
+    return current_branch in protected or any(
+        re.match(p, current_branch) for p in patterns
     )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-b', '--branch', action='append',
+        '-b',
+        '--branch',
+        action='append',
         help='branch to disallow commits to, may be specified multiple times',
     )
     parser.add_argument(
-        '-p', '--pattern', action='append',
+        '-p',
+        '--pattern',
+        action='append',
         help=(
             'regex pattern for branch name to disallow commits to, '
             'may be specified multiple times'
@@ -41,7 +49,20 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     protected = frozenset(args.branch or ('master', 'main'))
     patterns = frozenset(args.pattern or ())
-    return int(is_on_branch(protected, patterns))
+    current_branch = get_current_branch()
+
+    if current_branch is None:
+        return 0
+
+    on_branch = is_on_branch(current_branch, protected, patterns)
+
+    if on_branch:
+        print(
+            f'You are currently on {current_branch} branch, for which '
+            f'pre-commit script does not permit this action.',
+        )
+
+    return int(on_branch)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Prints a user-friendly message in case the action is disallowed on a branch. As of now it just shows "error", which is fine if you added the hook, but terrible UX for people using it in some project (e.g. installed automatically in devcontainer) for the 1st time.