### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add this to your `.pre-commit-config.yaml`
 
 #### `check-added-large-files`
 Prevent giant files from being committed.
-  - Specify what is "too large" with `args: ['--maxkb=123']` (default=500kB).
+  - Specify what is "too large" with `args: ['--maxkb 1024k']` (default=500kB).
   - Limits checked files to those indicated as staged for addition by git.
   - If `git-lfs` is installed, lfs files will be skipped
     (requires `git-lfs>=2.2.1`)


### PR DESCRIPTION
fixed check-added-large-files `args` syntax example.