### PR TITLE
add note for `end-of-file-fixer` to run `trailing-whitespace` first, so you don't have to run and stage twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Checks for the existence of private keys.
 This hook replaces double quoted strings with single quoted strings.
 
 #### `end-of-file-fixer`
-Makes sure files end in a newline and only a newline.
+Makes sure files end in a newline and only a newline. Should be run _after_ `trailing-whitespace` in order to handle files that end with spaces.
 
 #### `file-contents-sorter`
 Sort the lines in specified files (defaults to alphabetical).


### PR DESCRIPTION
See https://github.com/pre-commit/pre-commit-hooks/issues/997 for example