### PR TITLE
feat: add conventional commit check

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -95,6 +95,17 @@
     entry: check-yaml
     language: python
     types: [yaml]
+
+-   id: conventional-commit-msg
+    name: conventional commit message
+    # type(scope)?: description (body)? (footer)? (lowercase, present tense, and no period at the end)
+    language: pygrep
+    entry: '^(chore|test|feat|fix|build|docs|refactor)!?(\([a-z]+\))?: (?![A-Z][a-z])(?![a-z]+(ed|ing)\s).*$'
+    args:
+    - --multiline
+    - --negate # fails if the entry is NOT matched
+    stages: [commit-msg]
+
 -   id: debug-statements
     name: debug statements (python)
     description: checks for debugger imports and py37+ `breakpoint()` calls in python source.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Attempts to load all yaml files to verify syntax.
     portability to other yaml implementations.
     Implies `--allow-multiple-documents`.
 
+#### `conventional-commit-msg`
+Check if the top line of a commit message follows the
+[conventional rules](https://www.conventionalcommits.org/en/v1.0.0/).
+The message is expected in format: `type(scope)?: description (body)? (footer)?`
+Where description is in lowercase, present tense, and no period at the end.
+
 #### `debug-statements`
 Check for debugger imports and py37+ `breakpoint()` calls in python source.
 


### PR DESCRIPTION
Add simple pygrep expression for basic checking of conventional commit message in `commit-msg` stage