### PR TITLE
Extend check for illegal Windows filenames

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -44,9 +44,9 @@
     minimum_pre_commit_version: 3.2.0
 -   id: check-illegal-windows-names
     name: check illegal windows names
-    entry: Illegal windows filenames detected
+    entry: Illegal Windows filenames detected
     language: fail
-    files: '(?i)((^|/)(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\.|/|$)|:)'
+    files: '(?i)((^|/)(CON|PRN|AUX|NUL|COM[\d¹²³]|LPT[\d¹²³])(\.|/|$)|[<>:\"\\|?*\x00-\x1F]|/[^/]*[\.\s]/|[^/]*[\.\s]$)'
 -   id: check-json
     name: check json
     description: checks json files for parseable syntax.

--- a/tests/check_illegal_windows_names_test.py
+++ b/tests/check_illegal_windows_names_test.py
@@ -30,6 +30,17 @@ def hook_re():
         pytest.param('com7.dat', id='com with digit'),
         pytest.param(':', id='bare colon'),
         pytest.param('file:Zone.Identifier', id='mid colon'),
+        pytest.param('path/COM¹.json', id='com with superscript'),
+        pytest.param('dir/LPT³.toml', id='lpt with superscript'),
+        pytest.param('with < less than', id='with less than'),
+        pytest.param('Fast or Slow?.md', id='with question mark'),
+        pytest.param('with "double" quotes', id='with double quotes'),
+        pytest.param('with_null\x00byte', id='with null byte'),
+        pytest.param('ends_with.', id='ends with period'),
+        pytest.param('ends_with ', id='ends with space'),
+        pytest.param('ends_with\t', id='ends with tab'),
+        pytest.param('dir/ends./with.txt', id='directory ends with period'),
+        pytest.param('dir/ends /with.txt', id='directory ends with space'),
     ),
 )
 def test_check_illegal_windows_names_matches(hook_re, s):
@@ -42,6 +53,10 @@ def test_check_illegal_windows_names_matches(hook_re, s):
         pytest.param('README.md', id='standard file'),
         pytest.param('foo.aux', id='as ext'),
         pytest.param('com.dat', id='com without digit'),
+        pytest.param('.python-version', id='starts with period'),
+        pytest.param(' pseudo nan', id='with spaces'),
+        pytest.param('!@#$%^&;=≤\'~`¡¿€🤗', id='with allowed characters'),
+        pytest.param('path.to/file.py', id='standard path'),
     ),
 )
 def test_check_illegal_windows_names_does_not_match(hook_re, s):


### PR DESCRIPTION
Fixes #1048. It took some time to get it right, but I'm pretty sure this covers every possible illegal file name now. 

For reference, the following names are illegal on Windows:
- A name with any of the characters `< > : " \ | ? *` or any characters in the ASCII range `0-31`
- CON, PRN, AUX, NUL, COM0, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, COM¹, COM², COM³, LPT0, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9, LPT¹, LPT², and LPT³
- A name ending with a space or period