### PR TITLE
Feature: Add support for sections in requirements-fixer

### DIFF
--- a/tests/requirements_txt_fixer_test.py
+++ b/tests/requirements_txt_fixer_test.py
@@ -107,6 +107,25 @@ from pre_commit_hooks.requirements_txt_fixer import Requirement
             PASS,
             b'a=2.0.0 \\\n --hash=sha256:abcd\nb==1.0.0\n',
         ),
+        (
+            (
+                b'-c external.txt\n'
+                b'\n'
+                b'Peach\n'
+                b'apple\n'
+                b'banana\n'
+                b'pear\n'
+            ),
+            FAIL,
+            (
+                b'-c external.txt\n'
+                b'\n'
+                b'apple\n'
+                b'banana\n'
+                b'Peach\n'
+                b'pear\n'
+            ),
+        ),
     ),
 )
 def test_integration(input_s, expected_retval, output, tmpdir):


### PR DESCRIPTION
Opening for discussion and tweaking. This is possibly also a feature we may want to put behind a flag in some way.

`requirements-fixer` has been very useful as a pre-commit hook but we have often found that it doesnt respect "sections" or requirements files that have been purposefully split from each other by new lines.

For example we might have something like

```
# global constraints should be set here
-c constraints.txt

# machine learning requirements go here
numpy
scikit-learn

# other requirements go here
requests
structlog
```

in this case we would want each of the sections to be sorted individually.

This PR adds this functionality to sort sections independently