### PR TITLE
set stages for `destroyed-symlinks`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -115,6 +115,7 @@
     entry: destroyed-symlinks
     language: python
     types: [file]
+    stages: [pre-commit, pre-push, manual]
 -   id: detect-aws-credentials
     name: detect aws credentials
     description: detects *your* aws credentials from the aws cli credentials file.


### PR DESCRIPTION
The 'destroyed-symlinks' hook runs upon 'commit-msg' hook, however when used in 'git submodules', repository scope breaks

> pre_commit_hooks.util.CalledProcessError: (('git', 'status',
> '--porcelain=v2', '-z', '--', '.../COMMIT_EDITMSG'), 0, 128, '',
> b"fatal: .../COMMIT_EDITMSG: '...' is outside repository at '...'\n")
---

---

**Related issues :** Similar to #777 

---

**Test case using `docker run --entrypoint sh --rm -it python:3.12` container for example (+ `4.6.0` workaround) :**

```bash
# Configurations
if ! git config --global --get user.email; then
  git config --global user.email 'you@example.com'
  git config --global user.name 'Your Name'
fi

# Prepare main
mkdir ./main/
cd ./main/
git init
echo '# Main' >./README.md
git add -v ./README.md
git commit -m 'docs(readme): initial commit'
cd ../

# Create submodule1
mkdir ./submodule1/
cd ./submodule1/
git init
echo '# Submodule 1' >./README.md
git add ./README.md
git commit -m 'docs(readme): initial commit'
cd ../

# Create submodule2
mkdir ./submodule2
cd ./submodule2
git init
echo '# Submodule 2' >./README.md
git add ./README.md
git commit -m 'docs(readme): initial commit'
cd ../

# Add submodules
cd ./main/
mkdir ./sources/
git -c protocol.file.allow=always submodule add file://$(pwd)/../submodule1 ./sources/submodule1
git -c protocol.file.allow=always submodule add file://$(pwd)/../submodule2 ./sources/submodule2
git add -v ./sources/submodule1 ./sources/submodule2
git commit -m 'test(sources): add submodule1 and submodule2'
git status
git submodule

# Configure pre-commit in submodule1
cd ./sources/submodule1/
cat >./.pre-commit-config.yaml <<EOF
repos:
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v4.6.0
    hooks:
      - id: destroyed-symlinks
  - repo: https://github.com/commitizen-tools/commitizen
    rev: v3.29.0
    hooks:
      - id: commitizen
EOF
ls -la
pwd

# Install pre-commit
pip install pre-commit==3.8.0 # latest

# Enable pre-commit
pre-commit install -t commit-msg -t post-checkout -t post-commit -t post-merge -t post-rewrite -t pre-commit -t pre-merge-commit -t pre-push -t pre-rebase -t prepare-commit-msg

# Create commit
git add -v ./.pre-commit-config.yaml
git commit -m 'test(pre-commit): initial configuration'

# Run pre-commit (FAILURE)
pre-commit run -a -v

# Workaround destroyed-symlinks stages
cat >./.pre-commit-config.yaml <<EOF
repos:
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v4.6.0
    hooks:
      - id: destroyed-symlinks
        stages: [commit, push, manual]
  - repo: https://github.com/commitizen-tools/commitizen
    rev: v3.29.0
    hooks:
      - id: commitizen
EOF

# Run pre-commit (SUCCESS)
pre-commit run -a -v
```
