### PR TITLE
Fix wrong target for sort-simple-yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -201,7 +201,7 @@
     description: sorts simple yaml files which consist only of top-level keys, preserving comments and blocks.
     language: python
     entry: sort-simple-yaml
-    files: '^$'
+    types: [yaml]
 -   id: trailing-whitespace
     name: trim trailing whitespace
     description: trims trailing whitespace.


### PR DESCRIPTION
Configure sort-simple-yaml to apply to only yaml files.