### PR TITLE
Fix grammar of check-shebang-scripts error

### DIFF
--- a/pre_commit_hooks/check_shebang_scripts_are_executable.py
+++ b/pre_commit_hooks/check_shebang_scripts_are_executable.py
@@ -36,7 +36,7 @@ def _message(path: str) -> None:
         f'`chmod +x {shlex.quote(path)}`\n'
         f'  If on Windows, you may also need to: '
         f'`git add --chmod=+x {shlex.quote(path)}`\n'
-        f'  If it not supposed to be executable, double-check its shebang '
+        f'  If it is not supposed to be executable, double-check its shebang '
         f'is wanted.\n',
         file=sys.stderr,
     )


### PR DESCRIPTION
Minor fix to the grammar of the error that prints when check-shebang-scripts fails.