### PR TITLE
Fix debugger statement hook to catch dundle imports

### DIFF
--- a/pre_commit_hooks/debug_statement_hook.py
+++ b/pre_commit_hooks/debug_statement_hook.py
@@ -48,7 +48,7 @@ class DebugStatementParser(ast.NodeVisitor):
             if isinstance(node.args[0], ast.Constant) and node.args[0].value in DEBUG_STATEMENTS:
                 st = Debug(node.lineno, node.col_offset, node.args[0].value, 'imported')
                 self.breakpoints.append(st)
-        
+
         """python3.7+ breakpoint()"""
         if isinstance(node.func, ast.Name) and node.func.id == 'breakpoint':
             st = Debug(node.lineno, node.col_offset, node.func.id, 'called')

--- a/pre_commit_hooks/debug_statement_hook.py
+++ b/pre_commit_hooks/debug_statement_hook.py
@@ -44,6 +44,11 @@ class DebugStatementParser(ast.NodeVisitor):
             self.breakpoints.append(st)
 
     def visit_Call(self, node: ast.Call) -> None:
+        if isinstance(node, ast.Call) and len(node.args):
+            if isinstance(node.args[0], ast.Constant) and node.args[0].value in DEBUG_STATEMENTS:
+                st = Debug(node.lineno, node.col_offset, node.args[0].value, 'imported')
+                self.breakpoints.append(st)
+        
         """python3.7+ breakpoint()"""
         if isinstance(node.func, ast.Name) and node.func.id == 'breakpoint':
             st = Debug(node.lineno, node.col_offset, node.func.id, 'called')

--- a/tests/debug_statement_hook_test.py
+++ b/tests/debug_statement_hook_test.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import ast
 
+import pytest
+
 from pre_commit_hooks.debug_statement_hook import Debug
 from pre_commit_hooks.debug_statement_hook import DebugStatementParser
 from pre_commit_hooks.debug_statement_hook import main
@@ -26,10 +28,24 @@ def test_finds_debug_import_from_import():
     assert visitor.breakpoints == [Debug(1, 0, 'pudb', 'imported')]
 
 
-def test_finds_debug_import_when_using_dunder_import():
+@pytest.mark.parametrize(
+    'debugger_module', (
+        'bpdb',
+        'ipdb',
+        'pdb',
+        'pdbr',
+        'pudb',
+        'pydevd_pycharm',
+        'q',
+        'rdb',
+        'rpdb',
+        'wdb'
+    )
+)
+def test_finds_debug_import_when_using_dunder_import(debugger_module):
     visitor = DebugStatementParser()
-    visitor.visit(ast.parse('__import__("pdb").set_trace()'))
-    assert visitor.breakpoints == [Debug(1, 0, 'pdb', 'imported')]
+    visitor.visit(ast.parse(f'__import__("{debugger_module}").set_trace()'))
+    assert visitor.breakpoints == [Debug(1, 0, debugger_module, 'imported')]
 
 
 def test_finds_breakpoint():

--- a/tests/debug_statement_hook_test.py
+++ b/tests/debug_statement_hook_test.py
@@ -26,6 +26,12 @@ def test_finds_debug_import_from_import():
     assert visitor.breakpoints == [Debug(1, 0, 'pudb', 'imported')]
 
 
+def test_finds_debug_import_when_using_dunder_import():
+    visitor = DebugStatementParser()
+    visitor.visit(ast.parse('__import__("pdb").set_trace()'))
+    assert visitor.breakpoints == [Debug(1, 0, 'pdb', 'imported')]
+
+
 def test_finds_breakpoint():
     visitor = DebugStatementParser()
     visitor.visit(ast.parse('breakpoint()'))

--- a/tests/debug_statement_hook_test.py
+++ b/tests/debug_statement_hook_test.py
@@ -39,8 +39,8 @@ def test_finds_debug_import_from_import():
         'q',
         'rdb',
         'rpdb',
-        'wdb'
-    )
+        'wdb',
+    ),
 )
 def test_finds_debug_import_when_using_dunder_import(debugger_module):
     visitor = DebugStatementParser()


### PR DESCRIPTION
Added support to catch dundle imports of debugger modules on the debugger statement hook. Closes #1146 