### PR TITLE
Find private keys within gzip-compresssed files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -127,7 +127,7 @@
     description: detects the presence of private keys.
     entry: detect-private-key
     language: python
-    types: [text]
+    types_or: [text, tgz, gz]
 -   id: double-quote-string-fixer
     name: fix double quoted strings
     description: replaces double quoted strings with single quoted strings.

--- a/pre_commit_hooks/detect_private_key.py
+++ b/pre_commit_hooks/detect_private_key.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import gzip
 from collections.abc import Sequence
 
 BLACKLIST = [
@@ -29,6 +30,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             content = f.read()
             if any(line in content for line in BLACKLIST):
                 private_key_files.append(filename)
+                continue
+        try:
+            if filename.endswith(('.gz', '.tgz')):
+                with gzip.open(filename, 'rb') as f:
+                    content = f.read()
+                    if any(line in content for line in BLACKLIST):
+                        private_key_files.append(filename)
+                        continue
+        except gzip.BadGzipFile:
+            pass
 
     if private_key_files:
         for private_key_file in private_key_files:

--- a/tests/detect_private_key_test.py
+++ b/tests/detect_private_key_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import gzip
+
 import pytest
 
 from pre_commit_hooks.detect_private_key import main
@@ -26,3 +28,16 @@ def test_main(input_s, expected_retval, tmpdir):
     path = tmpdir.join('file.txt')
     path.write_binary(input_s)
     assert main([str(path)]) == expected_retval
+
+
+@pytest.mark.parametrize(('input_s', 'expected_retval'), TESTS)
+def test_main_gzip(input_s, expected_retval, tmpdir):
+    path = tmpdir.join('file.txt.gz')
+    path.write_binary(gzip.compress(input_s))
+    assert main([str(path)]) == expected_retval
+
+
+def test_main_gz_not_gzip(tmpdir):
+    path = tmpdir.join('file.txt.gz')
+    path.write_binary(b'not a sensitive value nor gzip')
+    assert main([str(path)]) == 0


### PR DESCRIPTION
Unfortunately we have run into a situation where this was necessary but the precommit did not detect it.