### PR TITLE
Adds note to Readme about `check-docstring-first`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Check for files with names that would conflict on a case-insensitive filesystem 
 #### `check-docstring-first`
 Checks for a common error of placing code before the docstring.
 
-> [!NOTE]  
+> [!NOTE]
 > As raised in [#159](https://github.com/pre-commit/pre-commit-hooks/issues/159) attribute level docstrings will
 > be flagged by this. A basic workaround is to wrap the docstring with `()` which will bypass this throwing and
 > error, but could interfere with other libraries that parse them.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ Check for files with names that would conflict on a case-insensitive filesystem 
 #### `check-docstring-first`
 Checks for a common error of placing code before the docstring.
 
+> [!NOTE]  
+> As raised in [#159](https://github.com/pre-commit/pre-commit-hooks/issues/159) attribute level docstrings will
+> be flagged by this. A basic workaround is to wrap the docstring with `()` which will bypass this throwing and
+> error, but could interfere with other libraries that parse them.
+
+<details><summary>Example</summary>
+
+```python
+variable = 42
+("""Attribute docstring""")
+```
+
+</details>
+
 #### `check-executables-have-shebangs`
 Checks that non-binary executables have a proper shebang.
 


### PR DESCRIPTION
I bumped into the same issue raised in #159. I found a quick workaround after looking at the code, and updated the Readme with a note for anyone else looking for the same. 

Using VS Code (ver 1.99.3) I was able to add an attribute docstring wrapped in `()` and still get the docstring hint on hover, without `pre-commit-hooks` flagging the file.

![image](https://github.com/user-attachments/assets/faeec609-8c23-4cc2-bd26-5c40ea90a828)
