### PR TITLE
Handle CRLF and mixed-ending files

### DIFF
--- a/pre_commit_hooks/end_of_file_fixer.py
+++ b/pre_commit_hooks/end_of_file_fixer.py
@@ -20,10 +20,13 @@ def fix_file(file_obj: IO[bytes]) -> int:
     last_character = file_obj.read(1)
     # last_character will be '' for an empty file
     if last_character not in {LF, CR} and last_character != b'':
-        # Check if file uses CRLF endings
+        # Check for consistent CRLF usage
         file_obj.seek(0, os.SEEK_SET)
         content = file_obj.read()
-        ending = CRLF if CRLF in content else LF
+        lf_count = content.count(LF)
+        crlf_count = content.count(CRLF)
+        # Use CRLF only if all line endings are CRLF
+        ending = CRLF if crlf_count > 0 and crlf_count == lf_count else LF
         # Needs this seek for windows, otherwise IOError
         file_obj.seek(0, os.SEEK_END)
         file_obj.write(ending)

--- a/tests/end_of_file_fixer_test.py
+++ b/tests/end_of_file_fixer_test.py
@@ -19,6 +19,7 @@ TESTS = (
     (b'\xe2\x98\x83', 1, b'\xe2\x98\x83\n'),
     (b'foo\r\n', 0, b'foo\r\n'),
     (b'foo\r\nbar', 1, b'foo\r\nbar\r\n'),
+    (b'foo\nbar\r\nbaz', 1, b'foo\nbar\r\nbaz\n'),
     (b'foo\r\n\r\n\r\n', 1, b'foo\r\n'),
     (b'foo\r', 0, b'foo\r'),
     (b'foo\r\r\r\r', 1, b'foo\r'),


### PR DESCRIPTION
Changes for `end-of-file-fixer`.

Refactor the handling of line endings to support files with CRLF and mixed endings.
In the first case, it will add a CRLF for the last line.
In the second case, it will default to LF for the last line.