### PR TITLE
file_contents_sorter: add --group-cases-together -- a better case-insensitive sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Note that this hook WILL remove blank lines and does NOT respect any comments.
 All newlines will be converted to line feeds (`\n`).
 
 The following arguments are available:
-- `--ignore-case` - fold lower case to upper case characters.
+- `--ignore-case` - fold lower case to upper case characters. this retains the original order of lines that differ only in case, so you probably want `--group-cases-together` instead.
+- `--group-cases-together` - group lines that differ only in case together, so e.g. `c`, `b`, `a`, and `B` are sorted to `a`, `B`, `b`, and `c` instead of `B`, `a`, `b`, and `c`.
 - `--unique` - ensure each line is unique.
 
 #### `fix-byte-order-marker`

--- a/tests/file_contents_sorter_test.py
+++ b/tests/file_contents_sorter_test.py
@@ -56,6 +56,30 @@ from pre_commit_hooks.file_contents_sorter import PASS
             b'fee\nfee\nFie\nFoe\nfum\n',
         ),
         (
+            b'a\nb\nB\nb\nc\n',
+            ['--ignore-case'],
+            PASS,
+            b'a\nb\nB\nb\nc\n',
+        ),
+        (
+            b'a\nb\nB\nb\nc\n',
+            ['--group-cases-together'],
+            FAIL,
+            b'a\nB\nb\nb\nc\n',
+        ),
+        (
+            b'fee\nFie\nFoe\nfum\n',
+            ['--group-cases-together'],
+            PASS,
+            b'fee\nFie\nFoe\nfum\n',
+        ),
+        (
+            b'Fie\nFoe\nfee\nfee\nfum\n',
+            ['--group-cases-together'],
+            FAIL,
+            b'fee\nfee\nFie\nFoe\nfum\n',
+        ),
+        (
             b'Fie\nFoe\nfee\nfum\n',
             ['--unique'],
             PASS,
@@ -66,6 +90,24 @@ from pre_commit_hooks.file_contents_sorter import PASS
             ['--unique'],
             FAIL,
             b'Fie\nFoe\nfee\nfum\n',
+        ),
+        (
+            b'a\nb\nB\nb\nc\n',
+            ['--group-cases-together', '--unique'],
+            FAIL,
+            b'a\nB\nb\nc\n',
+        ),
+        (
+            b'fee\nFie\nFoe\nfum\n',
+            ['--group-cases-together', '--unique'],
+            PASS,
+            b'fee\nFie\nFoe\nfum\n',
+        ),
+        (
+            b'Fie\nFoe\nfee\nfee\nfum\n',
+            ['--group-cases-together', '--unique'],
+            FAIL,
+            b'fee\nFie\nFoe\nfum\n',
         ),
     ),
 )


### PR DESCRIPTION
The new `--group-cases-together` option groups lines that differ only in case together, so e.g.:
```
c
b
a
B
```
is sorted to:
```
a
B
b
c
```
instead of:
```
B
a
b
c
```
It also works with `--unique`.

The `--ignore-case` option keeps lines that differ only in case in the original sorted order, whereas the new option will sort them (and remove duplicates if you pass `--unique`).

I added a new option instead of changing `--ignore-case` for backward compatibility with existing commit hooks so it doesn't break CI.

better naming suggestions are welcome.