### PR TITLE
Add --exclude to large files filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Add this to your `.pre-commit-config.yaml`
 #### `check-added-large-files`
 Prevent giant files from being committed.
   - Specify what is "too large" with `args: ['--maxkb=123']` (default=500kB).
+  - Optionally exclude glob-like patterns with `args: ['--exclude=uv.lock,examples/*ipynb']`
   - Limits checked files to those indicated as staged for addition by git.
   - If `git-lfs` is installed, lfs files will be skipped
     (requires `git-lfs>=2.2.1`)

--- a/tests/check_added_large_files_test.py
+++ b/tests/check_added_large_files_test.py
@@ -43,6 +43,23 @@ def test_add_something_giant(temp_git_dir):
         assert find_large_added_files(['f.py'], 10) == 0
 
 
+def test_use_exclude(temp_git_dir):
+    with temp_git_dir.as_cwd():
+        temp_git_dir.join('uv.lock').write('a' * 10_000)
+        temp_git_dir.join('big.baddie').write('a' * 10_000)
+
+        cmd_output('git', 'add', 'uv.lock')
+        cmd_output('git', 'add', 'big.baddie')
+
+        # should fail due to big baddie as thats not excluded
+        assert find_large_added_files(
+            ['uv.lock', 'big.baddie'], 1, exclude=['*.lock'],
+        ) == 1
+        # should pass when all files excluded, with both expand and exact match
+        assert find_large_added_files(['uv.lock'], 1, exclude=['*.lock']) == 0
+        assert find_large_added_files(['uv.lock'], 1, exclude=['uv.lock']) == 0
+
+
 def test_enforce_all(temp_git_dir):
     with temp_git_dir.as_cwd():
         temp_git_dir.join('f.py').write('a' * 10000)


### PR DESCRIPTION
We often don't want to add large files by mistake, but there are some cases where this is legit, like large uv locks or jupyter notebooks. But they are not that large to warrant git-lfs, and we don't want to increase the 500 kB limit globally because of those