### PR TITLE
[check_merge_conflict] Look for all 3 git conflict markers.

### DIFF
--- a/pre_commit_hooks/check_merge_conflict.py
+++ b/pre_commit_hooks/check_merge_conflict.py
@@ -43,7 +43,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             for i, line in enumerate(inputfile, start=1):
                 # Look for conflict patterns in order
                 if line.startswith(
-                    CONFLICT_PATTERNS[expected_conflict_pattern_index]
+                    CONFLICT_PATTERNS[expected_conflict_pattern_index],
                 ):
                     expected_conflict_pattern_index += 1
                     if expected_conflict_pattern_index == N:

--- a/tests/check_merge_conflict_test.py
+++ b/tests/check_merge_conflict_test.py
@@ -113,18 +113,19 @@ def test_merge_conflicts_git(capsys):
     # Individual markers are not actually merge conflicts, need 3 markers
     # to mark a real conflict
     'contents, expected_retcode',
-    ((b'<<<<<<< ', 0),
-     (b'=======', 0),
-     (b'>>>>>>> ',0),
-     # Real conflict marker
-     (b'<<<<<<< HEAD\n=======\n>>>>>>> branch\n', 1),
-     # Allow for the possibility of an .rst file with a =======
-     # inside a conflict marker
-     (b'<<<<<<< HEAD\n=======\n=======\n>>>>>>> branch\n', 1),
-    )
+    (
+        (b'<<<<<<< ', 0),
+        (b'=======', 0),
+        (b'>>>>>>> ', 0),
+        # Real conflict marker
+        (b'<<<<<<< HEAD\n=======\n>>>>>>> branch\n', 1),
+        # Allow for the possibility of an .rst file with a =======
+        # inside a conflict marker
+        (b'<<<<<<< HEAD\n=======\n=======\n>>>>>>> branch\n', 1),
+    ),
 )
 def test_merge_conflicts_with_rst(
-    contents, expected_retcode, repository_pending_merge
+    contents, expected_retcode, repository_pending_merge,
 ):
     repository_pending_merge.join('f2.rst').write_binary(contents)
     assert main(['f2.rst']) == expected_retcode
@@ -149,6 +150,7 @@ def test_does_not_care_when_not_in_a_merge(tmpdir):
     f.write_binary(b'problem\n=======\n')
     assert main([str(f.realpath())]) == 0
 
+
 @pytest.mark.parametrize(
     'contents, expected_retcode',
     (
@@ -156,7 +158,7 @@ def test_does_not_care_when_not_in_a_merge(tmpdir):
         (b'=======', 0),
         # Complete conflict marker
         (b'<<<<<<< HEAD\nproblem\n=======\n>>>>>>> branch\n', 1),
-    )
+    ),
 )
 def test_care_when_assumed_merge(contents, expected_retcode, tmpdir):
     f = tmpdir.join('README.md')


### PR DESCRIPTION
This PR is an attempt to fix known false positive `check_merge_conflict` checks in the presence of Restructured text files, by detecting all 3 conflict markers.

This is a known issue and has been noted before: #100 , #55. In particular, this is the most relevant comment: https://github.com/pre-commit/pre-commit-hooks/issues/100#issuecomment-529991100
> mergetool can probably detect when all three markers are there -- but this hook is intended to also prevent the cases where one or more of the markers have been deleted which makes this much trickier (and much more prone to false positives)....I'm not sure what the right answer is here

To state up front, I'm not sure what the right answer is either. The above comment mentions detecting a broken conflict marker as a desired use case, which this PR unfortunately breaks. If that is really the desire in all cases, then the status quo is better and this PR should be closed, which I'm totally fine with. 

I'm coming from the use case of running `pre-commit` in Python codebases with many `.rst` files, and whenever I'm committing a merge I need to perform some sort of workaround, which is admittedly for me too often adding a `SKIP=check-merge-conflict` env var when I've verified I have no conflicts using other tools.  I do think this is a rather common use-case, is it enough though to override the desire to detect broken conflict markers?

Perhaps a better solution is to use this new algorithm in `.rst` files, and the existing algorithm in all others? That might be a good compromise.