### PR TITLE
Pins ruamel.yaml dependency version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    ruamel.yaml>=0.15
+    ruamel.yaml>=0.15,<0.19
     tomli>=1.1.0;python_version<"3.11"
 python_requires = >=3.10
 


### PR DESCRIPTION
The latest version of ruamel.yaml changed a dependency, that now needs to be built.

See: https://pypi.org/project/ruamel.yaml/
> Starting with 0.19.0 ruamel.yaml no longer has ruamel.yaml.clib as a dependency, as this has been replaced with ruamel.yaml.clibz. The C sources are functionally unchanged, but they are now always compiled (using setuptools-zig and ziglang) on your system, instead of being downloaded as pre-compiled wheels (if available). For this to function properly your Python (virtual) environment needs to have an up-to-date version of setuptools and wheels pre-installed.

Since version 0.18 works fine, I think it's better for now to stick to pinning it (it won't harm)

Currently all our pre-commit executions in CI are failing as no compliers and stuffs are installed:
```
      × Building wheel for ruamel.yaml.clibz (pyproject.toml) did not run successfully.
      │ exit code: 1
      ╰─> [9 lines of output]
          /tmp/pip-build-env-2uc0vbcr/overlay/lib/python3.14/site-packages/setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'build_zig'
            warnings.warn(msg)
          running bdist_wheel
          running build
          running build_ext
          building '_ruamel_yaml_clibz' extension
          creating build/temp.linux-aarch64-cpython-314
          cc -pthread -fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -g -O3 -Wall -O3 -fPIC -fPIC -I/home/runner/.cache/pre-commit/repozf926m7l/py_env-python3.14/include -I/home/runner/.local/share/mise/installs/python/3.14.2/include/python3.14 -c _ruamel_yaml_clibz.c -o build/temp.linux-aarch64-cpython-314/_ruamel_yaml_clibz.o
          error: command 'cc' failed: No such file or directory
          [end of output]
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
      ERROR: Failed building wheel for ruamel.yaml.clibz
    error: failed-wheel-build-for-install
```

Fixes: https://github.com/pre-commit/pre-commit-hooks/issues/1233