### PR TITLE
Correct argv parameter type

### DIFF
--- a/pre_commit_hooks/check_added_large_files.py
+++ b/pre_commit_hooks/check_added_large_files.py
@@ -4,7 +4,7 @@ import argparse
 import math
 import os
 import subprocess
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from pre_commit_hooks.util import added_files
 from pre_commit_hooks.util import zsplit
@@ -54,7 +54,7 @@ def find_large_added_files(
     return retv
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         'filenames', nargs='*',

--- a/pre_commit_hooks/check_added_large_files.py
+++ b/pre_commit_hooks/check_added_large_files.py
@@ -4,7 +4,8 @@ import argparse
 import math
 import os
 import subprocess
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
+from collections.abc import Sequence
 
 from pre_commit_hooks.util import added_files
 from pre_commit_hooks.util import zsplit

--- a/pre_commit_hooks/check_ast.py
+++ b/pre_commit_hooks/check_ast.py
@@ -5,7 +5,7 @@ import ast
 import platform
 import sys
 import traceback
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 
 def main(argv: Iterable[str] | None = None) -> int:

--- a/pre_commit_hooks/check_ast.py
+++ b/pre_commit_hooks/check_ast.py
@@ -5,10 +5,10 @@ import ast
 import platform
 import sys
 import traceback
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/check_builtin_literals.py
+++ b/pre_commit_hooks/check_builtin_literals.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import ast
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import NamedTuple
 
 
@@ -70,7 +70,7 @@ def parse_ignore(value: str) -> set[str]:
     return set(value.split(','))
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
     parser.add_argument('--ignore', type=parse_ignore, default=set())

--- a/pre_commit_hooks/check_builtin_literals.py
+++ b/pre_commit_hooks/check_builtin_literals.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import ast
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from typing import NamedTuple
 
 

--- a/pre_commit_hooks/check_case_conflict.py
+++ b/pre_commit_hooks/check_case_conflict.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 from collections.abc import Iterable
 from collections.abc import Iterator
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from pre_commit_hooks.util import added_files
 from pre_commit_hooks.util import cmd_output
@@ -56,7 +56,7 @@ def find_conflicting_filenames(filenames: Sequence[str]) -> int:
     return retv
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         'filenames', nargs='*',

--- a/pre_commit_hooks/check_case_conflict.py
+++ b/pre_commit_hooks/check_case_conflict.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 from collections.abc import Iterable
 from collections.abc import Iterator
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 
 from pre_commit_hooks.util import added_files
 from pre_commit_hooks.util import cmd_output

--- a/pre_commit_hooks/check_docstring_first.py
+++ b/pre_commit_hooks/check_docstring_first.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import io
 import tokenize
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from tokenize import tokenize as tokenize_tokenize
 
 NON_CODE_TOKENS = frozenset((

--- a/pre_commit_hooks/check_docstring_first.py
+++ b/pre_commit_hooks/check_docstring_first.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import io
 import tokenize
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from tokenize import tokenize as tokenize_tokenize
 
 NON_CODE_TOKENS = frozenset((
@@ -46,7 +46,7 @@ def check_docstring_first(src: bytes, filename: str = '<unknown>') -> int:
     return 0
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/check_executables_have_shebangs.py
+++ b/pre_commit_hooks/check_executables_have_shebangs.py
@@ -5,7 +5,8 @@ import argparse
 import shlex
 import sys
 from collections.abc import Generator
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
+from collections.abc import Sequence
 from typing import NamedTuple
 
 from pre_commit_hooks.util import cmd_output

--- a/pre_commit_hooks/check_executables_have_shebangs.py
+++ b/pre_commit_hooks/check_executables_have_shebangs.py
@@ -5,7 +5,7 @@ import argparse
 import shlex
 import sys
 from collections.abc import Generator
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import NamedTuple
 
 from pre_commit_hooks.util import cmd_output
@@ -73,7 +73,7 @@ def _message(path: str) -> None:
     )
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('filenames', nargs='*')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/check_json.py
+++ b/pre_commit_hooks/check_json.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from typing import Any
 
 

--- a/pre_commit_hooks/check_json.py
+++ b/pre_commit_hooks/check_json.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 
@@ -18,7 +18,7 @@ def raise_duplicate_keys(
     return d
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to check.')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/check_merge_conflict.py
+++ b/pre_commit_hooks/check_merge_conflict.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os.path
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from pre_commit_hooks.util import cmd_output
 
@@ -28,7 +28,7 @@ def is_in_merge() -> bool:
     )
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
     parser.add_argument('--assume-in-merge', action='store_true')

--- a/pre_commit_hooks/check_merge_conflict.py
+++ b/pre_commit_hooks/check_merge_conflict.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os.path
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 from pre_commit_hooks.util import cmd_output
 

--- a/pre_commit_hooks/check_shebang_scripts_are_executable.py
+++ b/pre_commit_hooks/check_shebang_scripts_are_executable.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 import argparse
 import shlex
 import sys
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
+from collections.abc import Sequence
 
 from pre_commit_hooks.check_executables_have_shebangs import EXECUTABLE_VALUES
 from pre_commit_hooks.check_executables_have_shebangs import git_ls_files

--- a/pre_commit_hooks/check_shebang_scripts_are_executable.py
+++ b/pre_commit_hooks/check_shebang_scripts_are_executable.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import argparse
 import shlex
 import sys
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from pre_commit_hooks.check_executables_have_shebangs import EXECUTABLE_VALUES
 from pre_commit_hooks.check_executables_have_shebangs import git_ls_files
@@ -42,7 +42,7 @@ def _message(path: str) -> None:
     )
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('filenames', nargs='*')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/check_symlinks.py
+++ b/pre_commit_hooks/check_symlinks.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import argparse
 import os.path
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description='Checks for broken symlinks.')
     parser.add_argument('filenames', nargs='*', help='Filenames to check')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/check_symlinks.py
+++ b/pre_commit_hooks/check_symlinks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os.path
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 
 def main(argv: Iterable[str] | None = None) -> int:

--- a/pre_commit_hooks/check_toml.py
+++ b/pre_commit_hooks/check_toml.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib

--- a/pre_commit_hooks/check_toml.py
+++ b/pre_commit_hooks/check_toml.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
@@ -10,7 +10,7 @@ else:  # pragma: <3.11 cover
     import tomli as tomllib
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to check.')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/check_vcs_permalinks.py
+++ b/pre_commit_hooks/check_vcs_permalinks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from re import Pattern
 
 
@@ -28,7 +28,7 @@ def _check_filename(filename: str, patterns: list[Pattern[bytes]]) -> int:
     return retv
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
     parser.add_argument(

--- a/pre_commit_hooks/check_vcs_permalinks.py
+++ b/pre_commit_hooks/check_vcs_permalinks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from re import Pattern
 
 

--- a/pre_commit_hooks/check_xml.py
+++ b/pre_commit_hooks/check_xml.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import argparse
 import xml.sax.handler
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='XML filenames to check.')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/check_xml.py
+++ b/pre_commit_hooks/check_xml.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import xml.sax.handler
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 
 def main(argv: Iterable[str] | None = None) -> int:

--- a/pre_commit_hooks/check_yaml.py
+++ b/pre_commit_hooks/check_yaml.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Generator
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from typing import Any
 from typing import NamedTuple
 

--- a/pre_commit_hooks/check_yaml.py
+++ b/pre_commit_hooks/check_yaml.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Generator
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import Any
 from typing import NamedTuple
 
@@ -37,7 +37,7 @@ LOAD_FNS = {
 }
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '-m', '--multi', '--allow-multiple-documents', action='store_true',

--- a/pre_commit_hooks/debug_statement_hook.py
+++ b/pre_commit_hooks/debug_statement_hook.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import ast
 import traceback
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from typing import NamedTuple
 
 

--- a/pre_commit_hooks/debug_statement_hook.py
+++ b/pre_commit_hooks/debug_statement_hook.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import ast
 import traceback
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import NamedTuple
 
 
@@ -71,7 +71,7 @@ def check_file(filename: str) -> int:
     return int(bool(visitor.breakpoints))
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to run')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/destroyed_symlinks.py
+++ b/pre_commit_hooks/destroyed_symlinks.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import argparse
 import shlex
 import subprocess
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
+from collections.abc import Sequence
 
 from pre_commit_hooks.util import cmd_output
 from pre_commit_hooks.util import zsplit

--- a/pre_commit_hooks/destroyed_symlinks.py
+++ b/pre_commit_hooks/destroyed_symlinks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import shlex
 import subprocess
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from pre_commit_hooks.util import cmd_output
 from pre_commit_hooks.util import zsplit
@@ -66,7 +66,7 @@ def find_destroyed_symlinks(files: Sequence[str]) -> list[str]:
     return destroyed_links
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to check.')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/detect_aws_credentials.py
+++ b/pre_commit_hooks/detect_aws_credentials.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import configparser
 import os
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import NamedTuple
 
 
@@ -89,7 +89,7 @@ def check_file_for_aws_keys(
     return bad_files
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='+', help='Filenames to run')
     parser.add_argument(

--- a/pre_commit_hooks/detect_aws_credentials.py
+++ b/pre_commit_hooks/detect_aws_credentials.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import argparse
 import configparser
 import os
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
+from collections.abc import Sequence
 from typing import NamedTuple
 
 

--- a/pre_commit_hooks/detect_private_key.py
+++ b/pre_commit_hooks/detect_private_key.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 BLACKLIST = [
     b'BEGIN RSA PRIVATE KEY',

--- a/pre_commit_hooks/detect_private_key.py
+++ b/pre_commit_hooks/detect_private_key.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 BLACKLIST = [
     b'BEGIN RSA PRIVATE KEY',
@@ -17,7 +17,7 @@ BLACKLIST = [
 ]
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to check')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/end_of_file_fixer.py
+++ b/pre_commit_hooks/end_of_file_fixer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from typing import IO
 
 

--- a/pre_commit_hooks/end_of_file_fixer.py
+++ b/pre_commit_hooks/end_of_file_fixer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import IO
 
 
@@ -49,7 +49,7 @@ def fix_file(file_obj: IO[bytes]) -> int:
     return 0
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/file_contents_sorter.py
+++ b/pre_commit_hooks/file_contents_sorter.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 from collections.abc import Iterable
-from collections.abc import Iterable
 from typing import Any
 from typing import IO
 

--- a/pre_commit_hooks/file_contents_sorter.py
+++ b/pre_commit_hooks/file_contents_sorter.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 from collections.abc import Iterable
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from typing import Any
 from typing import IO
 

--- a/pre_commit_hooks/file_contents_sorter.py
+++ b/pre_commit_hooks/file_contents_sorter.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 from collections.abc import Iterable
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import Any
 from typing import IO
 
@@ -51,7 +51,7 @@ def sort_file_contents(
         return FAIL
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='+', help='Files to sort')
 

--- a/pre_commit_hooks/fix_byte_order_marker.py
+++ b/pre_commit_hooks/fix_byte_order_marker.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 
 def main(argv: Iterable[str] | None = None) -> int:

--- a/pre_commit_hooks/fix_byte_order_marker.py
+++ b/pre_commit_hooks/fix_byte_order_marker.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to check')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/forbid_new_submodules.py
+++ b/pre_commit_hooks/forbid_new_submodules.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 from pre_commit_hooks.util import cmd_output
 

--- a/pre_commit_hooks/forbid_new_submodules.py
+++ b/pre_commit_hooks/forbid_new_submodules.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import argparse
 import os
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from pre_commit_hooks.util import cmd_output
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/mixed_line_ending.py
+++ b/pre_commit_hooks/mixed_line_ending.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import collections
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 
 CRLF = b'\r\n'

--- a/pre_commit_hooks/mixed_line_ending.py
+++ b/pre_commit_hooks/mixed_line_ending.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import collections
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 
 CRLF = b'\r\n'
@@ -62,7 +62,7 @@ def fix_filename(filename: str, fix: str) -> int:
         return other_endings
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '-f', '--fix',

--- a/pre_commit_hooks/no_commit_to_branch.py
+++ b/pre_commit_hooks/no_commit_to_branch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from typing import AbstractSet
 
 from pre_commit_hooks.util import CalledProcessError

--- a/pre_commit_hooks/no_commit_to_branch.py
+++ b/pre_commit_hooks/no_commit_to_branch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import AbstractSet
 
 from pre_commit_hooks.util import CalledProcessError
@@ -24,7 +24,7 @@ def is_on_branch(
     )
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '-b', '--branch', action='append',

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import sys
 from collections.abc import Mapping
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from difflib import unified_diff
 
 
@@ -55,7 +55,7 @@ def get_diff(source: str, target: str, file: str) -> str:
     return ''.join(diff)
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--autofix',

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Iterable
 from collections.abc import Mapping
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from difflib import unified_diff
 
 

--- a/pre_commit_hooks/removed.py
+++ b/pre_commit_hooks/removed.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 
 def main(argv: Iterable[str] | None = None) -> int:

--- a/pre_commit_hooks/removed.py
+++ b/pre_commit_hooks/removed.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     argv = argv if argv is not None else sys.argv[1:]
     hookid, new_hookid, url = argv[:3]
     raise SystemExit(

--- a/pre_commit_hooks/requirements_txt_fixer.py
+++ b/pre_commit_hooks/requirements_txt_fixer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import IO
 
 
@@ -142,7 +142,7 @@ def fix_requirements(f: IO[bytes]) -> int:
         return FAIL
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/requirements_txt_fixer.py
+++ b/pre_commit_hooks/requirements_txt_fixer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from typing import IO
 
 

--- a/pre_commit_hooks/sort_simple_yaml.py
+++ b/pre_commit_hooks/sort_simple_yaml.py
@@ -20,7 +20,7 @@ complicated YAML files.
 from __future__ import annotations
 
 import argparse
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 
 QUOTES = ["'", '"']
@@ -99,7 +99,7 @@ def first_key(lines: list[str]) -> str:
         return ''  # not actually reached in reality
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/sort_simple_yaml.py
+++ b/pre_commit_hooks/sort_simple_yaml.py
@@ -20,7 +20,7 @@ complicated YAML files.
 from __future__ import annotations
 
 import argparse
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 
 QUOTES = ["'", '"']

--- a/pre_commit_hooks/string_fixer.py
+++ b/pre_commit_hooks/string_fixer.py
@@ -5,7 +5,7 @@ import io
 import re
 import sys
 import tokenize
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 if sys.version_info >= (3, 12):  # pragma: >=3.12 cover
     FSTRING_START = tokenize.FSTRING_START
@@ -73,7 +73,7 @@ def fix_strings(filename: str) -> int:
         return 0
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/string_fixer.py
+++ b/pre_commit_hooks/string_fixer.py
@@ -5,7 +5,7 @@ import io
 import re
 import sys
 import tokenize
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 if sys.version_info >= (3, 12):  # pragma: >=3.12 cover
     FSTRING_START = tokenize.FSTRING_START

--- a/pre_commit_hooks/tests_should_end_in_test.py
+++ b/pre_commit_hooks/tests_should_end_in_test.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import argparse
 import os.path
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
     mutex = parser.add_mutually_exclusive_group()

--- a/pre_commit_hooks/tests_should_end_in_test.py
+++ b/pre_commit_hooks/tests_should_end_in_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import os.path
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 
 def main(argv: Iterable[str] | None = None) -> int:

--- a/pre_commit_hooks/trailing_whitespace_fixer.py
+++ b/pre_commit_hooks/trailing_whitespace_fixer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 
 def _fix_file(

--- a/pre_commit_hooks/trailing_whitespace_fixer.py
+++ b/pre_commit_hooks/trailing_whitespace_fixer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 
 def _fix_file(
@@ -41,7 +41,7 @@ def _process_line(
     return line.rstrip(chars) + eol
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--no-markdown-linebreak-ext',


### PR DESCRIPTION
I recently noticed that **typeshed** has widened the type of `args` parameter in `argparse.parse_args` method from **Sequence[str]** to **Iterable[str]** ([typeshed#15613](https://github.com/python/typeshed/pull/15613)).

I believe it’s necessary to update the types of variables passed to parse_args to stay consistent with this change.