### PR TITLE
Allow sorting file contents on windows machines

### DIFF
--- a/pre_commit_hooks/file_contents_sorter.py
+++ b/pre_commit_hooks/file_contents_sorter.py
@@ -29,18 +29,21 @@ def sort_file_contents(
     unique: bool = False,
 ) -> int:
     before = list(f)
+    # detect the line ending style of the file, based on the first line
+    new_line = b'\r\n' if before and before[0].endswith(b'\r\n') else b'\n'
+
     lines: Iterable[bytes] = (
-        line.rstrip(b'\n\r') for line in before if line.strip()
+        line.rstrip(new_line) for line in before if line.strip()
     )
     if unique:
         lines = set(lines)
     after = sorted(lines, key=key)
 
     before_string = b''.join(before)
-    after_string = b'\n'.join(after)
+    after_string = new_line.join(after)
 
     if after_string:
-        after_string += b'\n'
+        after_string += new_line
 
     if before_string == after_string:
         return PASS

--- a/tests/file_contents_sorter_test.py
+++ b/tests/file_contents_sorter_test.py
@@ -12,11 +12,14 @@ from pre_commit_hooks.file_contents_sorter import PASS
     (
         (b'', [], PASS, b''),
         (b'\n', [], FAIL, b''),
+        (b'\r\n', [], FAIL, b''),
         (b'\n\n', [], FAIL, b''),
         (b'lonesome\n', [], PASS, b'lonesome\n'),
         (b'missing_newline', [], FAIL, b'missing_newline\n'),
         (b'newline\nmissing', [], FAIL, b'missing\nnewline\n'),
         (b'missing\nnewline', [], FAIL, b'missing\nnewline\n'),
+        (b'newline\r\nmissing', [], FAIL, b'missing\r\nnewline\r\n'),
+        (b'missing\r\nnewline', [], FAIL, b'missing\r\nnewline\r\n'),
         (b'alpha\nbeta\n', [], PASS, b'alpha\nbeta\n'),
         (b'beta\nalpha\n', [], FAIL, b'alpha\nbeta\n'),
         (b'C\nc\n', [], PASS, b'C\nc\n'),
@@ -25,6 +28,8 @@ from pre_commit_hooks.file_contents_sorter import PASS
         (b'@\n-\n_\n#\n', [], FAIL, b'#\n-\n@\n_\n'),
         (b'extra\n\n\nwhitespace\n', [], FAIL, b'extra\nwhitespace\n'),
         (b'whitespace\n\n\nextra\n', [], FAIL, b'extra\nwhitespace\n'),
+        (b'on\r\nwindows\r\n', [], PASS, b'on\r\nwindows\r\n'),
+        (b'extra\r\n\r\n\r\nwindows\r\n', [], FAIL, b'extra\r\nwindows\r\n'),
         (
             b'fee\nFie\nFoe\nfum\n',
             [],


### PR DESCRIPTION
I ran into this issue, because in one of our CI/CD pipeline's we run the pre-commit checks on a windows image, which would result in a puzzling output from the `file_contents_sorter` hook.

Before the hook would perform a `.rstrip(b'\n\r')` on all lines, removing the CR character, and then join the lines together, only using `'\n'`, resulting in white space differences that are hard to spot.

With this PR the newline sequence of the first line is used to determine how to strip and join the lines before and after sorting.

Added unit tests to ensure consistent behaviour on windows.